### PR TITLE
Refactor RPC code

### DIFF
--- a/packages/omg-js-childchain/src/index.js
+++ b/packages/omg-js-childchain/src/index.js
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-const watcherApi = require('./watcherApi')
+const watcherApi = require('./rpc/watcherApi')
+const childchainApi = require('./rpc/childchainApi')
 const sign = require('./transaction/signature')
-const submitTx = require('./transaction/submitRPC')
 const transaction = require('./transaction/transaction')
 const rlp = require('rlp')
 const { InvalidArgumentError } = require('@omisego/omg-js-util')
@@ -138,7 +138,12 @@ class ChildChain {
    */
   async submitTransaction (transaction) {
     // validateTxBody(transactionBody)
-    return submitTx(transaction, this.childChainUrl)
+    return childchainApi.post(`${this.childChainUrl}`, {
+      method: 'submit',
+      params: {
+        transaction
+      }
+    })
   }
 
   /**

--- a/packages/omg-js-childchain/src/rpc/watcherApi.js
+++ b/packages/omg-js-childchain/src/rpc/watcherApi.js
@@ -13,26 +13,31 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-// Get_block on JSON RPC
+const rpcApi = require('./rpcApi')
 
-const fetch = require('node-fetch')
-
-async function getBlock (blockhash, childchainUrl) {
-  let payload = {
-    'params': {
-      'hash': blockhash
-    },
-    'method': 'get_block',
-    'jsonrpc': '2.0',
-    'id': 0
+class WatcherError extends Error {
+  constructor ({ code, description }) {
+    super(description)
+    this.code = code
   }
-
-  let resp = await fetch(childchainUrl, {
-    method: 'POST',
-    body: JSON.stringify(payload)
-  })
-
-  return resp.json()
 }
 
-module.exports = getBlock
+async function get (url) {
+  return rpcApi.get(url).then(handleResponse)
+}
+
+async function post (url, body) {
+  return rpcApi.post(url, body, { 'Content-Type': 'application/json' }).then(handleResponse)
+}
+
+function handleResponse (response) {
+  if (response.result === 'error') {
+    throw new WatcherError(response.data)
+  }
+  return response.data
+}
+
+module.exports = {
+  get,
+  post
+}


### PR DESCRIPTION
Both the Watcher and the ChildChain APIs are JSON-RPC
Unfortunately, they both have slightly different calling and error conventions.
I've put common code into `rpcApi.js` and service specific code into `watcherApi.js` and `childchainApi.js`
