### PR TITLE
fix: Bump tar to 4.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4037,7 +4037,7 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true,

--- a/packages/integration-tests/package-lock.json
+++ b/packages/integration-tests/package-lock.json
@@ -2144,8 +2144,8 @@
 			}
 		},
 		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.2.tgz",
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"requires": {
 				"block-stream": "*",


### PR DESCRIPTION
Not sure if this is the correct way to bump `tar` in JS land?