### PR TITLE
Deposit events

### DIFF
--- a/packages/integration-tests/test/depositTest.js
+++ b/packages/integration-tests/test/depositTest.js
@@ -58,6 +58,48 @@ describe('Deposit tests', async () => {
       }
     })
 
+    it('depositEth calls event emitter if passed', async () => {
+      const depositTx = transaction.encodeDeposit(aliceAccount.address, TEST_AMOUNT, transaction.ETH_CURRENCY)
+
+      let confirmationNum
+      let receipt
+
+      await new Promise((resolve, reject) => {
+        rootChain.depositEth(
+          depositTx,
+          TEST_AMOUNT,
+          {
+            from: aliceAccount.address,
+            privateKey: aliceAccount.privateKey
+          },
+          {
+            onConfirmation: res => confirmationNum = res,
+            onReceipt: res => {
+              receipt = res
+              resolve()
+            }
+          }
+        )
+      })
+
+      assert.isNumber(confirmationNum)
+      assert.isObject(receipt)
+    })
+
+    it('deposit call resolves in an object containing the transaction hash', async () => {
+      const depositTx = transaction.encodeDeposit(aliceAccount.address, TEST_AMOUNT, transaction.ETH_CURRENCY)
+      const depositRes = await rootChain.depositEth(
+        depositTx,
+        TEST_AMOUNT,
+        {
+          from: aliceAccount.address,
+          privateKey: aliceAccount.privateKey
+        }
+      )
+      assert.isObject(depositRes)
+      assert.isString(depositRes.transactionHash)
+    })
+
     it('should deposit ETH to the Plasma contract', async () => {
       // The new account should have no initial balance
       const initialBalance = await childChain.getBalance(aliceAccount.address)

--- a/packages/omg-js-rootchain/src/rootchain.js
+++ b/packages/omg-js-rootchain/src/rootchain.js
@@ -47,9 +47,10 @@ class RootChain {
    * @param {string} depositTx RLP encoded childchain deposit transaction
    * @param {number} amount amount of ETH to deposit
    * @param {Object} txOptions transaction options, such as `from`, `gas` and `privateKey`
-   * @return {string} transaction hash of the call
+   * @param {Object} [callBacks] callbacks to events from the transaction lifecycle
+   * @return {Promise<{ transactionHash: string }>} promise that resolves with an object holding the transaction hash
    */
-  async depositEth (depositTx, amount, txOptions) {
+  async depositEth (depositTx, amount, txOptions, callBacks) {
     const txDetails = {
       from: txOptions.from,
       to: this.plasmaContractAddress,
@@ -63,8 +64,7 @@ class RootChain {
       gas: txOptions.gas,
       gasPrice: txOptions.gasPrice
     }
-
-    return txUtils.sendTx(this.web3, txDetails, txOptions.privateKey)
+    return txUtils.sendTx(this.web3, txDetails, txOptions.privateKey, callBacks)
   }
 
   /**

--- a/packages/omg-js-rootchain/src/txUtils.js
+++ b/packages/omg-js-rootchain/src/txUtils.js
@@ -2,6 +2,7 @@
  * Send transaction using web3
  *
  * @method sendTx
+ * @private
  * @param web3 the web3 object to access the Ethereum network
  * @param {object} txDetails transaction details object
  * @param {string} privateKey private key

--- a/packages/omg-js-rootchain/src/txUtils.js
+++ b/packages/omg-js-rootchain/src/txUtils.js
@@ -1,26 +1,51 @@
-async function sendTx (web3, txDetails, privateKey) {
+/**
+ * Send transaction using web3
+ *
+ * @method sendTx
+ * @param web3 the web3 object to access the Ethereum network
+ * @param {object} txDetails transaction details object
+ * @param {string} privateKey private key
+ * @param {{ onReceipt: any, onConfirmation: any }} [callBacks] callbacks to use during transaction lifecycle
+ * @return {Promise<{ transactionHash: string }>} promise that resolves with the transaction hash
+ */
+async function sendTx (web3, txDetails, privateKey, callBacks) {
   await setGas(web3, txDetails)
   if (!privateKey) {
     // No privateKey, caller will handle signing if necessary
     if (web3.version.api && web3.version.api.startsWith('0.2')) {
       return new Promise((resolve, reject) => {
         web3.eth.sendTransaction(txDetails, (err, transactionHash) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve({ transactionHash })
-          }
+          err
+            ? reject(err)
+            : resolve({ transactionHash })
         })
       })
-    } else {
-      return web3.eth.sendTransaction(txDetails)
     }
-  } else {
-    // First sign the transaction
-    const signedTx = await web3.eth.accounts.signTransaction(txDetails, prefixHex(privateKey))
-    // Then send it
-    return web3.eth.sendSignedTransaction(signedTx.rawTransaction)
+    if (callBacks) {
+      return new Promise((resolve, reject) => {
+        web3.eth.sendTransaction(txDetails)
+          .on('receipt', callBacks.onReceipt)
+          .on('confirmation', callBacks.onConfirmation)
+          .on('transactionHash', hash => resolve({ transactionHash: hash }))
+          .on('error', reject)
+      })
+    }
+    return web3.eth.sendTransaction(txDetails)
   }
+
+  // First sign the transaction
+  const signedTx = await web3.eth.accounts.signTransaction(txDetails, prefixHex(privateKey))
+  // Then send it
+  if (callBacks) {
+    return new Promise((resolve, reject) => {
+      web3.eth.sendSignedTransaction(signedTx.rawTransaction)
+        .on('receipt', callBacks.onReceipt)
+        .on('confirmation', callBacks.onConfirmation)
+        .on('transactionHash', hash => resolve({ transactionHash: hash }))
+        .on('error', reject)
+    })
+  }
+  return web3.eth.sendSignedTransaction(signedTx.rawTransaction)
 }
 
 async function setGas (web3, txDetails) {


### PR DESCRIPTION
Ran into this while working on the ewallet... I couldn't use the transaction events from the `depositEth` method on `rootchain`.
ie. needed the `transactionHash`, `confirmation` and `receipt` events to dictate what screen to show to the user during deposit lifecycle

the `async` wrapper on these methods will return a promise which masks the ability to call `.on` on the returned `promiEvents` from web3. 

not sure if something we want to support 