### PR TITLE
Clean metadata

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1620,7 +1620,7 @@
                 <tr>
   <td class='break-word'><span class='code bold'>args.metadata</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?</code>
   </td>
-  <td class='break-word'><span>the metadata to include in the transaction. Must be a 32-byte hex string
+  <td class='break-word'><span>the metadata to include in the transaction
 </span></td>
 </tr>
 

--- a/examples/childchain-inflight-exit-eth.js
+++ b/examples/childchain-inflight-exit-eth.js
@@ -78,8 +78,7 @@ async function inflightExitChildChain () {
   const createdTxn = await childChain.createTransaction({
     owner: aliceAddress,
     payments,
-    fee,
-    metadata: transaction.NULL_METADATA
+    fee
   })
   console.log(`Created a childchain transaction of ${web3.utils.fromWei(payments[0].amount.toString(), 'ether')} ETH from Alice to Bob.`)
 

--- a/examples/childchain-transaction-erc20.js
+++ b/examples/childchain-transaction-erc20.js
@@ -58,14 +58,11 @@ async function erc20Transaction () {
     amount: 1
   }
 
-  const metadata = transaction.NULL_METADATA
-  // or encode using transaction.encodeMetadata('hello')
-
   const createdTxn = await childChain.createTransaction({
     owner: aliceAddress,
     payments,
     fee,
-    metadata
+    metadata: 'hello world'
   })
   console.log(`Created a childchain transaction of ${config.alice_erc20_transfer_amount} ERC20 from Alice to Bob.`)
   // type/sign/build/submit

--- a/examples/childchain-transaction-eth.js
+++ b/examples/childchain-transaction-eth.js
@@ -64,14 +64,11 @@ async function createSignBuildAndSubmitTransaction () {
     amount: Number(feeAmount)
   }
 
-  const metadata = transaction.NULL_METADATA
-  // or encode using transaction.encodeMetadata('hello')
-
   const createdTxn = await childChain.createTransaction({
     owner: aliceAddress,
     payments,
     fee,
-    metadata
+    metadata: 'hello'
   })
   console.log(`Created a childchain transaction of ${web3.utils.fromWei(payments[0].amount.toString(), 'ether')} ETH from Alice to Bob.`)
 

--- a/packages/integration-tests/helpers/childChainHelper.js
+++ b/packages/integration-tests/helpers/childChainHelper.js
@@ -166,8 +166,7 @@ async function sendSubmitTyped (childChain, from, to, amount, currency, fromPriv
   const createdTx = await childChain.createTransaction({
     owner: from,
     payments,
-    fee,
-    metadata: transaction.NULL_METADATA
+    fee
   })
   const privateKeys = new Array(createdTx.transactions[0].inputs.length).fill(fromPrivateKey)
   const txTypedData = childChain.signTypedData(createdTx.transactions[0], privateKeys)

--- a/packages/integration-tests/test/createSubmitTypedTransactionTest.js
+++ b/packages/integration-tests/test/createSubmitTypedTransactionTest.js
@@ -78,8 +78,7 @@ describe('Create transaction tests with submitTyped (ci-enabled)', function () {
       const createdTx = await childChain.createTransaction({
         owner: aliceAccount.address,
         payments,
-        fee,
-        metadata: transaction.NULL_METADATA
+        fee
       })
       assert.equal(createdTx.result, 'complete')
       assert.equal(createdTx.transactions.length, 1)

--- a/packages/integration-tests/test/createTransactionTest.js
+++ b/packages/integration-tests/test/createTransactionTest.js
@@ -79,8 +79,7 @@ describe('Create transaction tests', function () {
       const createdTx = await childChain.createTransaction({
         owner: aliceAccount.address,
         payments,
-        fee,
-        metadata: transaction.NULL_METADATA
+        fee
       })
       assert.equal(createdTx.result, 'complete')
       assert.equal(createdTx.transactions.length, 1)
@@ -113,11 +112,13 @@ describe('Create transaction tests', function () {
     const TRANSFER_AMOUNT = web3.utils.toWei('.0000001', 'ether')
     const FEE_AMOUNT = 10
     let aliceAccount
+    let bobAccount
 
     before(async function () {
       // Create Alice and Bob's accounts
       aliceAccount = rcHelper.createAccount(web3)
       console.log(`Created Alice account ${JSON.stringify(aliceAccount)}`)
+      bobAccount = rcHelper.createAccount(web3)
       // Give some ETH to Alice on the child chain
       await faucet.fundChildchain(aliceAccount.address, INTIIAL_ALICE_AMOUNT, transaction.ETH_CURRENCY)
       await ccHelper.waitForBalanceEq(childChain, aliceAccount.address, INTIIAL_ALICE_AMOUNT)
@@ -135,7 +136,8 @@ describe('Create transaction tests', function () {
     it('should create a single currency transaction', async function () {
       const payments = [{
         currency: transaction.ETH_CURRENCY,
-        amount: Number(TRANSFER_AMOUNT)
+        amount: Number(TRANSFER_AMOUNT),
+        owner: bobAccount.address
       }]
 
       const fee = {
@@ -146,8 +148,7 @@ describe('Create transaction tests', function () {
       const createdTx = await childChain.createTransaction({
         owner: aliceAccount.address,
         payments,
-        fee,
-        metadata: transaction.NULL_METADATA
+        fee
       })
       assert.equal(createdTx.result, 'complete')
       assert.equal(createdTx.transactions.length, 1)
@@ -207,8 +208,7 @@ describe('Create transaction tests', function () {
       const createdTx = await childChain.createTransaction({
         owner: aliceAccount.address,
         payments,
-        fee,
-        metadata: transaction.NULL_METADATA
+        fee
       })
       assert.equal(createdTx.result, 'complete')
       assert.equal(createdTx.transactions.length, 1)
@@ -293,8 +293,7 @@ describe('Create transaction tests', function () {
       const createdTx = await childChain.createTransaction({
         owner: aliceAccount.address,
         payments,
-        fee,
-        metadata: transaction.NULL_METADATA
+        fee
       })
       assert.equal(createdTx.result, 'intermediate')
       assert.equal(createdTx.transactions.length, 2)
@@ -319,8 +318,7 @@ describe('Create transaction tests', function () {
       const createdTx2 = await childChain.createTransaction({
         owner: aliceAccount.address,
         payments,
-        fee,
-        metadata: transaction.NULL_METADATA
+        fee
       })
       assert.equal(createdTx2.result, 'complete')
       assert.equal(createdTx2.transactions.length, 1)
@@ -387,8 +385,7 @@ describe('Create transaction tests', function () {
       const createdTx = await childChain.createTransaction({
         owner: aliceAccount.address,
         payments,
-        fee,
-        metadata: transaction.NULL_METADATA
+        fee
       })
       assert.equal(createdTx.result, 'complete')
       assert.equal(createdTx.transactions.length, 1)

--- a/packages/integration-tests/test/metadataTest.js
+++ b/packages/integration-tests/test/metadataTest.js
@@ -82,7 +82,7 @@ describe('Metadata tests (ci-enabled-fast)', function () {
           amount: 0,
           currency: transaction.ETH_CURRENCY
         },
-        metadata: transaction.encodeMetadata(METADATA),
+        metadata: METADATA,
         verifyingContract: rootChain.plasmaContractAddress
       })
       console.log(`Submitted transaction: ${JSON.stringify(result)}`)

--- a/packages/omg-js-childchain/src/validators/helpers.js
+++ b/packages/omg-js-childchain/src/validators/helpers.js
@@ -21,6 +21,14 @@ const validatePayment = Joi.object({
 
 const validatePayments = Joi.array().items(validatePayment)
 
+const validateMetadata = Joi.any().custom((value, helpers) => {
+  const bytesSize = Buffer.from(value).length
+  if (bytesSize > 32) {
+    return helpers.message(`"${value}" is too large. metadata cannot be larger than 32 bytes`)
+  }
+  return value
+})
+
 const validateFee = Joi.object({
   amount: [Joi.number().required(), Joi.string().required(), validateBn.required()],
   currency: validateAddress.required()
@@ -30,6 +38,7 @@ module.exports = {
   validateAddress,
   validatePayments,
   validatePayment,
+  validateMetadata,
   validateFee,
   validateBn
 }

--- a/packages/omg-js-childchain/src/validators/helpers.js
+++ b/packages/omg-js-childchain/src/validators/helpers.js
@@ -23,8 +23,13 @@ const validatePayments = Joi.array().items(validatePayment)
 
 const validateMetadata = Joi.string().custom((value, helpers) => {
   if (value.startsWith('0x')) {
+    const hex = Buffer.from(value.replace('0x', ''), 'hex')
+    if (hex.length !== 32) {
+      return helpers.message(`"${value}" metadata must be a 32-byte hex string`)
+    }
     return value
   }
+
   const bytesSize = Buffer.from(value).length
   if (bytesSize > 32) {
     return helpers.message(`"${value}" is too large. metadata cannot be larger than 32 bytes`)

--- a/packages/omg-js-childchain/src/validators/helpers.js
+++ b/packages/omg-js-childchain/src/validators/helpers.js
@@ -21,7 +21,10 @@ const validatePayment = Joi.object({
 
 const validatePayments = Joi.array().items(validatePayment)
 
-const validateMetadata = Joi.any().custom((value, helpers) => {
+const validateMetadata = Joi.string().custom((value, helpers) => {
+  if (value.startsWith('0x')) {
+    return value
+  }
   const bytesSize = Buffer.from(value).length
   if (bytesSize > 32) {
     return helpers.message(`"${value}" is too large. metadata cannot be larger than 32 bytes`)

--- a/packages/omg-js-childchain/src/validators/index.js
+++ b/packages/omg-js-childchain/src/validators/index.js
@@ -1,5 +1,12 @@
 const Joi = require('@hapi/joi')
-const { validateAddress, validatePayments, validatePayment, validateFee, validateBn } = require('./helpers')
+const {
+  validateAddress,
+  validatePayments,
+  validatePayment,
+  validateMetadata,
+  validateFee,
+  validateBn
+} = require('./helpers')
 
 const childchainConstructorSchema = Joi.object({
   watcherUrl: Joi.string().required(),
@@ -12,7 +19,7 @@ const getBalanceSchema = validateAddress.required()
 
 const getTransactionsSchema = Joi.object({
   address: validateAddress,
-  metadata: Joi.string().allow(null),
+  metadata: validateMetadata,
   blknum: Joi.number(),
   limit: Joi.number(),
   page: Joi.number()
@@ -34,7 +41,7 @@ const createTransactionSchema = Joi.object({
   owner: validateAddress.required(),
   payments: validatePayments.required(),
   fee: validateFee.required(),
-  metadata: Joi.string().allow(null)
+  metadata: validateMetadata
 })
 
 const signTypedDataSchema = Joi.object({
@@ -60,7 +67,7 @@ const sendTransactionSchema = Joi.object({
   fromPrivateKeys: Joi.array().items(Joi.string()).required(),
   payment: validatePayment.required(),
   fee: validateFee.required(),
-  metadata: Joi.string().allow(null),
+  metadata: validateMetadata,
   verifyingContract: validateAddress.required()
 })
 

--- a/packages/omg-js-util/src/transaction.js
+++ b/packages/omg-js-util/src/transaction.js
@@ -342,6 +342,9 @@ const transaction = {
   *
   */
   encodeMetadata: function (str) {
+    if (str.startsWith('0x')) {
+      return str
+    }
     const encodedMetadata = Buffer.from(str).toString('hex').padStart(64, '0')
     return `0x${encodedMetadata}`
   },

--- a/packages/omg-js-util/test/createTransactionBodyTest.js
+++ b/packages/omg-js-util/test/createTransactionBodyTest.js
@@ -29,8 +29,7 @@ describe('createTransactionBody', function () {
       fee: {
         amount: 0,
         currency: transaction.ETH_CURRENCY
-      },
-      metadata: undefined
+      }
     })
     assert.equal(txBody.outputs.length, 2)
     assert.equal(txBody.outputs[0].outputGuard, toAddress)
@@ -78,8 +77,7 @@ describe('createTransactionBody', function () {
       fee: {
         amount: 0,
         currency: transaction.ETH_CURRENCY
-      },
-      metadata: undefined
+      }
     })
     assert.equal(txBody.outputs.length, 2)
     assert.equal(txBody.outputs[0].outputGuard, toAddress)
@@ -127,8 +125,7 @@ describe('createTransactionBody', function () {
       fee: {
         amount: 0,
         currency: transaction.ETH_CURRENCY
-      },
-      metadata: undefined
+      }
     })
     assert.equal(txBody.outputs.length, 1)
     assert.equal(txBody.outputs[0].outputGuard, toAddress)
@@ -161,8 +158,7 @@ describe('createTransactionBody', function () {
       fee: {
         amount: 0,
         currency: transaction.ETH_CURRENCY
-      },
-      metadata: undefined
+      }
     })
     assert.equal(txBody.outputs.length, 1)
     assert.equal(txBody.outputs[0].outputGuard, toAddress)
@@ -203,8 +199,7 @@ describe('createTransactionBody', function () {
       fee: {
         amount: 50,
         currency: transaction.ETH_CURRENCY
-      },
-      metadata: undefined
+      }
     })
     assert.equal(txBody.outputs.length, 3)
     assert.equal(txBody.outputs[0].outputGuard, toAddress)
@@ -258,8 +253,7 @@ describe('createTransactionBody', function () {
       fee: {
         amount: 50,
         currency: fakeErc20
-      },
-      metadata: undefined
+      }
     })
     assert.equal(txBody.outputs.length, 3)
     assert.equal(txBody.outputs[0].outputGuard, toAddress)
@@ -307,8 +301,7 @@ describe('createTransactionBody', function () {
           fee: {
             amount: 0,
             currency: transaction.ETH_CURRENCY
-          },
-          metadata: undefined
+          }
         }),
       Error,
       /Insufficient funds/
@@ -357,8 +350,7 @@ describe('createTransactionBody', function () {
           fee: {
             amount: 0,
             currency: transaction.ETH_CURRENCY
-          },
-          metadata: undefined
+          }
         }),
       Error,
       /There are currencies in the utxo array that is not fee or currency./


### PR DESCRIPTION
- default to null_metadata when not passed
- can pass string directly (easier api), take care of the encoding in childchain lib
- catch with joi if string larger than 32 bytes

issue: [203](https://github.com/omisego/omg-js/issues/203)