### PR TITLE
Refactor transaction.createTransactionBody

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ Copy the `dist/omg.js` file into your project and include it.
 
 ## API Documentation
 
-[Documentation for omg-js ](http://omisego.github.io/omg-js)
+[Documentation for omg-js ](https://developer.omisego.co/omg-js/)
 
 ## Design Documentation
 
+[Sending a transaction](/integration-docs/transactions.md)  
 [How to sign a transaction](/integration-docs/signing-methods.md)
 
 ## Examples

--- a/docs/index.html
+++ b/docs/index.html
@@ -5221,16 +5221,16 @@ of the transaction, sending any remainder back as change.</p>
                 <tr>
   <td class='break-word'><span class='code bold'>args.fromUtxos</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>></code>
   </td>
-  <td class='break-word'><span>the utxos to use as transaction inputs
+  <td class='break-word'><span>the utxos to use as transaction inputs (in order of priority)
 </span></td>
 </tr>
 
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>args.payment</span> <code class='quiet'><a href="#payment">Payment</a></code>
+  <td class='break-word'><span class='code bold'>args.payments</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#payment">Payment</a>></code>
   </td>
-  <td class='break-word'><span>payment object specifying the output
+  <td class='break-word'><span>payment objects specifying the outputs
 </span></td>
 </tr>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1600,9 +1600,9 @@
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>args.payment</span> <code class='quiet'><a href="#payment">Payment</a></code>
+  <td class='break-word'><span class='code bold'>args.payments</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#payment">Payment</a>></code>
   </td>
-  <td class='break-word'><span>a payment object
+  <td class='break-word'><span>a payments object
 </span></td>
 </tr>
 

--- a/examples/childchain-deposit-erc20.js
+++ b/examples/childchain-deposit-erc20.js
@@ -43,7 +43,7 @@ async function logBalances () {
   console.log(`Alice's childchain ERC20 balance: ${childchainERC20Balance}`)
 }
 
-async function depositERC20IntoPlasmaContract () {
+async function childchainDepositErc20 () {
   if (!config.erc20_contract) {
     console.log('Please define an ERC20 contract address in your .env')
     return
@@ -90,4 +90,4 @@ async function depositERC20IntoPlasmaContract () {
   await logBalances()
 }
 
-depositERC20IntoPlasmaContract()
+childchainDepositErc20()

--- a/examples/childchain-deposit-eth.js
+++ b/examples/childchain-deposit-eth.js
@@ -44,7 +44,7 @@ async function logBalances () {
   console.log(`Alice's childchain ETH balance: ${childchainETHBalance}`)
 }
 
-async function depositEthIntoPlasmaContract () {
+async function childchainDepositEth () {
   await logBalances()
   console.log('-----')
 
@@ -75,4 +75,4 @@ async function depositEthIntoPlasmaContract () {
   await logBalances()
 }
 
-depositEthIntoPlasmaContract()
+childchainDepositEth()

--- a/examples/childchain-exit-erc20.js
+++ b/examples/childchain-exit-erc20.js
@@ -45,7 +45,7 @@ async function logBalances () {
   console.log(`Bob's childchain ERC20 balance: ${bobChildchainBalance}`)
 }
 
-async function exitChildChainErc20 () {
+async function childchainExitErc20 () {
   if (!config.erc20_contract) {
     console.log('Please define an ERC20 contract in your .env')
     return
@@ -132,4 +132,4 @@ async function exitChildChainErc20 () {
   await logBalances()
 }
 
-exitChildChainErc20()
+childchainExitErc20()

--- a/examples/childchain-exit-eth.js
+++ b/examples/childchain-exit-eth.js
@@ -41,7 +41,7 @@ async function logBalances () {
   console.log(`Bob's childchain balance: ${bobChildchainETHBalance}`)
 }
 
-async function exitChildChain () {
+async function childchainExitEth () {
   const bobRootchainBalance = await web3.eth.getBalance(bobAddress)
   const bobsEtherBalance = web3.utils.fromWei(String(bobRootchainBalance), 'ether')
   if (bobsEtherBalance < 0.001) {
@@ -125,4 +125,4 @@ async function exitChildChain () {
   await logBalances()
 }
 
-exitChildChain()
+childchainExitEth()

--- a/examples/childchain-inflight-exit-eth.js
+++ b/examples/childchain-inflight-exit-eth.js
@@ -52,7 +52,7 @@ async function logBalances () {
   console.log(`Bob's childchain ETH balance: ${bobsChildchainETHBalance}`)
 }
 
-async function inflightExitChildChain () {
+async function childchainInflightExitEth () {
   const bobRootchainBalance = await web3.eth.getBalance(bobAddress)
   const bobsEtherBalance = web3.utils.fromWei(String(bobRootchainBalance), 'ether')
   if (bobsEtherBalance < 0.001) {
@@ -159,4 +159,4 @@ async function inflightExitChildChain () {
   await logBalances()
 }
 
-inflightExitChildChain()
+childchainInflightExitEth()

--- a/examples/childchain-transaction-erc20.js
+++ b/examples/childchain-transaction-erc20.js
@@ -40,7 +40,7 @@ async function logBalances () {
   return { bobERC20Balance: bobsChildchainERC20Balance }
 }
 
-async function erc20Transaction () {
+async function childchainTransactionErc20 () {
   if (!config.erc20_contract) {
     console.log('Please define an ERC20 contract address in your .env')
     return
@@ -89,4 +89,4 @@ async function erc20Transaction () {
   await logBalances()
 }
 
-erc20Transaction()
+childchainTransactionErc20()

--- a/examples/childchain-transaction-eth.js
+++ b/examples/childchain-transaction-eth.js
@@ -47,7 +47,7 @@ async function logBalances () {
   return { bobETHBalance: bobsEthObject ? bobsEthObject.amount : 0 }
 }
 
-async function createSignBuildAndSubmitTransaction () {
+async function childchainTransactionEth () {
   const { bobETHBalance } = await logBalances()
   console.log('-----')
 
@@ -96,4 +96,4 @@ async function createSignBuildAndSubmitTransaction () {
   await logBalances()
 }
 
-createSignBuildAndSubmitTransaction()
+childchainTransactionEth()

--- a/integration-docs/transactions.md
+++ b/integration-docs/transactions.md
@@ -5,7 +5,7 @@ The `omg-js` api provides a few different ways to send a transaction on the OMG 
 ----------------- OLD API ---------------------
 
 Create a transaction body
-<!-- rename to childchain.createTransactionBodies -->
+<!-- rename to childchain.createTransactionData -->
 - `childchain.createTransaction` (uses the childchain endpoint to construct transaction bodies)
 - `transaction.createTransactionBody` (uses local logic to construct a transaction body)
 - manually define the transaction body yourself
@@ -14,15 +14,16 @@ Create a transaction body
 For full control of the transaction
 1. create a transaction body using a method explained above
 2. `transaction.getTypedData` (sanitizes transaction into the correct typedData format)
-<!-- should be renamed and moved to transaction.signTypedData (3 and 4 can be combined) -->
+<!-- should be renamed and moved to transaction.createSignedTransaction (3 and 4 can be combined) -->
 3. `childchain.signTransaction` (locally signs typedData with passed private keys, useful for multiple different signatures. can also use metamask to sign: see signing-methods.md)
 4. `childchain.buildSignedTransaction` (returns encoded and signed transaction ready to be submitted)
+<!-- rename to chilchain.submitSignedTransaction -->
 5. `childchain.submitTransaction` (submits to the childchain)
 
 ### METHOD B
 Relying on the childchain completely to create and send the transaction
 1. `childchain.createTransaction` (will construct a transaction body using the childchain)
-<!-- 2 and 3 can be combined as they are mutually exclusive -->
+<!-- make sure 2 can sign any kind of typedData, combine 2 and 3 -->
 2. `childchain.signTypedData` (locally will sign a transaction selected from `childchain.createTransaction`)
 3. `childchain.submitTyped` (will submit the result of `childchain.signTypedData`)
 
@@ -34,31 +35,28 @@ If you only need to define which UTXOs can be spent
 
 ----------------- PROPOSED API ---------------------
 
-The process of creating and submitting a transaction follows this transformative process:
+The process of creating and submitting a transaction follows this process:
 1. define a transaction body:                                   definition -> transactionBody
 2. convert that transaction body into typedData:                transactionBody -> typedData
 3. sign and encode that typedData into a signed transaction:    typedData -> signed transaction
-4. submit the transaction to the childchain:                    signed transaction -> receipt
+  - *or* sign and submit the typedData directly:                typedData -> transaction receipt
+4. submit the signed transaction to the childchain:             signed transaction -> transaction receipt
 
 ### Defining a transaction body
-3 ways to create a transaction body
 - `childchain.createTransactionData` (uses the childchain endpoint to construct transaction bodies)
 - `transaction.createTransactionBody` (uses local logic to construct a transaction body)
 - manually define the transaction body yourself
 
 ### Creating typedData
-2 ways to generate typedData
 - `childchain.createTransactionData` (uses the childchain endpoint to create typedData)
 - `transaction.getTypedData` (locally convert transactionBody into typedData)
 
+### Signing and submitting typedData directly
+- `childchain.submitTyped` (sign and submit typedData to the childchain)
+
 ### Signing typedData and creating a signed transaction
-only 1 way to sign typedData and create a signed transaction
-- `transaction.createSignedTransaction`
+- `transaction.createSignedTransaction` (locally sign and create an encoded transaction)
 
 ### Submitting signed transaction to the childchain
-only 1 way to submit the signed transaction
-- `childchain.submitSignedTransaction`
+- `childchain.submitSignedTransaction` (suibmit the encoded transaction to the childchain)
 
-### Sign and submit typedData directly
-An alternative method of signing and submitting typedData directly 
-- `childchain.submitTyped`

--- a/integration-docs/transactions.md
+++ b/integration-docs/transactions.md
@@ -1,0 +1,12 @@
+## Sending a transaction
+
+The `omg-js` api provides a few different ways to send a transaction on the OMG Network. 
+
+`childchain.createTransaction`
+`childchain.signTransaction`
+`childchain.buildSignedTransaction`
+`childchain.submitTransaction`
+`childchain.sendTransaction`
+
+`childchain.signTypedData`
+`childchain.submitTyped`

--- a/integration-docs/transactions.md
+++ b/integration-docs/transactions.md
@@ -23,7 +23,7 @@ For full control of the transaction
 5. `childchain.submitTransaction` (submits to the childchain)
 
 ### METHOD B
-Relying on the childchain completely to create and send the transaction
+Relying on the childchain completely to create and send the transaction. Note that this method will choose the UTXO for you by using the largest utxo of that specific currency (also you won't able to do 2 transactions in the same block using this method).
 1. `childchain.createTransaction` (will construct a transaction body using the childchain)
 2. `childchain.signTypedData` (locally will sign a transaction selected from `childchain.createTransaction`)
 3. `childchain.submitTyped` (will submit the result of `childchain.signTypedData`)

--- a/integration-docs/transactions.md
+++ b/integration-docs/transactions.md
@@ -2,11 +2,63 @@
 
 The `omg-js` api provides a few different ways to send a transaction on the OMG Network. 
 
-`childchain.createTransaction`
-`childchain.signTransaction`
-`childchain.buildSignedTransaction`
-`childchain.submitTransaction`
-`childchain.sendTransaction`
+----------------- OLD API ---------------------
 
-`childchain.signTypedData`
-`childchain.submitTyped`
+Create a transaction body
+<!-- rename to childchain.createTransactionBodies -->
+- `childchain.createTransaction` (uses the childchain endpoint to construct transaction bodies)
+- `transaction.createTransactionBody` (uses local logic to construct a transaction body)
+- manually define the transaction body yourself
+
+### METHOD A
+For full control of the transaction
+1. create a transaction body using a method explained above
+2. `transaction.getTypedData` (sanitizes transaction into the correct typedData format)
+<!-- should be renamed and moved to transaction.signTypedData (3 and 4 can be combined) -->
+3. `childchain.signTransaction` (locally signs typedData with passed private keys, useful for multiple different signatures. can also use metamask to sign: see signing-methods.md)
+4. `childchain.buildSignedTransaction` (returns encoded and signed transaction ready to be submitted)
+5. `childchain.submitTransaction` (submits to the childchain)
+
+### METHOD B
+Relying on the childchain completely to create and send the transaction
+1. `childchain.createTransaction` (will construct a transaction body using the childchain)
+<!-- 2 and 3 can be combined as they are mutually exclusive -->
+2. `childchain.signTypedData` (locally will sign a transaction selected from `childchain.createTransaction`)
+3. `childchain.submitTyped` (will submit the result of `childchain.signTypedData`)
+
+<!-- We can remove this method to simplify the api, and force typing, signing, and building -->
+### METHOD C
+If you only need to define which UTXOs can be spent
+1. `childchain.getUtxos` (first get all available UTXOs and then select what you want to spend)
+2. `childchain.sendTransaction` (internally will create/getTyped/sign/buildSigned/submit from the utxos you pass it)
+
+----------------- PROPOSED API ---------------------
+
+The process of creating and submitting a transaction follows this transformative process:
+1. define a transaction body:                                   definition -> transactionBody
+2. convert that transaction body into typedData:                transactionBody -> typedData
+3. sign and encode that typedData into a signed transaction:    typedData -> signed transaction
+4. submit the transaction to the childchain:                    signed transaction -> receipt
+
+### Defining a transaction body
+3 ways to create a transaction body
+- `childchain.createTransactionData` (uses the childchain endpoint to construct transaction bodies)
+- `transaction.createTransactionBody` (uses local logic to construct a transaction body)
+- manually define the transaction body yourself
+
+### Creating typedData
+2 ways to generate typedData
+- `childchain.createTransactionData` (uses the childchain endpoint to create typedData)
+- `transaction.getTypedData` (locally convert transactionBody into typedData)
+
+### Signing typedData and creating a signed transaction
+only 1 way to sign typedData and create a signed transaction
+- `transaction.createSignedTransaction`
+
+### Submitting signed transaction to the childchain
+only 1 way to submit the signed transaction
+- `childchain.submitSignedTransaction`
+
+### Sign and submit typedData directly
+An alternative method of signing and submitting typedData directly 
+- `childchain.submitTyped`

--- a/integration-docs/transactions.md
+++ b/integration-docs/transactions.md
@@ -1,39 +1,6 @@
 ## Sending a transaction
 
-The `omg-js` api provides a few different ways to send a transaction on the OMG Network. 
-
------------------ OLD API ---------------------
-
-Create a transaction body
-<!-- rename to childchain.createTransactionData -->
-- `childchain.createTransaction` (uses the childchain endpoint to construct transaction bodies)
-- `transaction.createTransactionBody` (uses local logic to construct a transaction body)
-- manually define the transaction body yourself
-
-### METHOD A
-For full control of the transaction
-1. create a transaction body using a method explained above
-2. `transaction.getTypedData` (sanitizes transaction into the correct typedData format)
-<!-- should be renamed and moved to transaction.createSignedTransaction (3 and 4 can be combined) -->
-3. `childchain.signTransaction` (locally signs typedData with passed private keys, useful for multiple different signatures. can also use metamask to sign: see signing-methods.md)
-4. `childchain.buildSignedTransaction` (returns encoded and signed transaction ready to be submitted)
-<!-- rename to chilchain.submitSignedTransaction -->
-5. `childchain.submitTransaction` (submits to the childchain)
-
-### METHOD B
-Relying on the childchain completely to create and send the transaction
-1. `childchain.createTransaction` (will construct a transaction body using the childchain)
-<!-- make sure 2 can sign any kind of typedData, combine 2 and 3 -->
-2. `childchain.signTypedData` (locally will sign a transaction selected from `childchain.createTransaction`)
-3. `childchain.submitTyped` (will submit the result of `childchain.signTypedData`)
-
-<!-- We can remove this method to simplify the api, and force typing, signing, and building -->
-### METHOD C
-If you only need to define which UTXOs can be spent
-1. `childchain.getUtxos` (first get all available UTXOs and then select what you want to spend)
-2. `childchain.sendTransaction` (internally will create/getTyped/sign/buildSigned/submit from the utxos you pass it)
-
------------------ PROPOSED API ---------------------
+The `omg-js` api provides a few different ways to send a transaction on the OMG Network.
 
 The process of creating and submitting a transaction follows this process:
 1. define a transaction body:                                   definition -> transactionBody
@@ -42,21 +9,26 @@ The process of creating and submitting a transaction follows this process:
   - *or* sign and submit the typedData directly:                typedData -> transaction receipt
 4. submit the signed transaction to the childchain:             signed transaction -> transaction receipt
 
-### Defining a transaction body
-- `childchain.createTransactionData` (uses the childchain endpoint to construct transaction bodies)
+Create a transaction body
+- `childchain.createTransaction` (uses the childchain endpoint to construct transaction bodies)
 - `transaction.createTransactionBody` (uses local logic to construct a transaction body)
 - manually define the transaction body yourself
 
-### Creating typedData
-- `childchain.createTransactionData` (uses the childchain endpoint to create typedData)
-- `transaction.getTypedData` (locally convert transactionBody into typedData)
+### METHOD A
+For full control of the transaction
+1. create a transaction body using a method explained above
+2. `transaction.getTypedData` (sanitizes transaction into the correct typedData format)
+3. `childchain.signTransaction` (locally signs typedData with passed private keys, useful for multiple different signatures. can also use metamask to sign: see signing-methods.md)
+4. `childchain.buildSignedTransaction` (returns encoded and signed transaction ready to be submitted)
+5. `childchain.submitTransaction` (submits to the childchain)
 
-### Signing and submitting typedData directly
-- `childchain.submitTyped` (sign and submit typedData to the childchain)
+### METHOD B
+Relying on the childchain completely to create and send the transaction
+1. `childchain.createTransaction` (will construct a transaction body using the childchain)
+2. `childchain.signTypedData` (locally will sign a transaction selected from `childchain.createTransaction`)
+3. `childchain.submitTyped` (will submit the result of `childchain.signTypedData`)
 
-### Signing typedData and creating a signed transaction
-- `transaction.createSignedTransaction` (locally sign and create an encoded transaction)
-
-### Submitting signed transaction to the childchain
-- `childchain.submitSignedTransaction` (suibmit the encoded transaction to the childchain)
-
+### METHOD C
+If you only need to define which UTXOs can be spent
+1. `childchain.getUtxos` (first get all available UTXOs and then select what you want to spend)
+2. `childchain.sendTransaction` (internally will create/getTyped/sign/buildSigned/submit from the utxos you pass it)

--- a/integration-docs/transactions.md
+++ b/integration-docs/transactions.md
@@ -18,7 +18,7 @@ Create a transaction body
 For full control of the transaction
 1. create a transaction body using a method explained above
 2. `transaction.getTypedData` (sanitizes transaction into the correct typedData format)
-3. `childchain.signTransaction` (locally signs typedData with passed private keys, useful for multiple different signatures. can also use metamask to sign: see signing-methods.md)
+3. `childchain.signTransaction` (locally signs typedData with passed private keys, useful for multiple different signatures. can also use metamask to sign: see [signing-methods](./signing-methods.md))
 4. `childchain.buildSignedTransaction` (returns encoded and signed transaction ready to be submitted)
 5. `childchain.submitTransaction` (submits to the childchain)
 

--- a/packages/integration-tests/test/metadataTest.js
+++ b/packages/integration-tests/test/metadataTest.js
@@ -73,11 +73,11 @@ describe('Metadata tests (ci-enabled-fast)', function () {
         fromAddress: aliceAccount.address,
         fromUtxos: utxos,
         fromPrivateKeys: [aliceAccount.privateKey],
-        payment: {
+        payments: [{
           owner: bobAccount.address,
           currency: transaction.ETH_CURRENCY,
           amount: TRANSFER_AMOUNT
-        },
+        }],
         fee: {
           amount: 0,
           currency: transaction.ETH_CURRENCY
@@ -137,11 +137,11 @@ describe('Metadata tests (ci-enabled-fast)', function () {
         fromAddress: aliceAccount.address,
         fromUtxos: utxos,
         fromPrivateKeys: [aliceAccount.privateKey],
-        payment: {
+        payments: [{
           owner: bobAccount.address,
           amount: TRANSFER_AMOUNT,
           currency: transaction.ETH_CURRENCY
-        },
+        }],
         fee: {
           amount: 0,
           currency: transaction.ETH_CURRENCY
@@ -196,11 +196,11 @@ describe('Metadata tests (ci-enabled-fast)', function () {
         fromAddress: aliceAccount.address,
         fromUtxos: utxos,
         fromPrivateKeys: [aliceAccount.privateKey],
-        payment: {
+        payments: [{
           owner: bobAccount.address,
           amount: TRANSFER_AMOUNT,
           currency: transaction.ETH_CURRENCY
-        },
+        }],
         fee: {
           amount: 0,
           currency: transaction.ETH_CURRENCY

--- a/packages/integration-tests/test/transferTest.js
+++ b/packages/integration-tests/test/transferTest.js
@@ -151,7 +151,7 @@ describe('Transfer tests', function () {
       // Check Alice's utxos on the child chain
       let aliceUtxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(aliceUtxos.length, 2)
-      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount'])
+      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
       assert.equal(aliceUtxos[0].amount.toString(), UTXO_AMOUNT)
       assert.equal(aliceUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(aliceUtxos[1].amount.toString(), UTXO_AMOUNT)
@@ -160,7 +160,7 @@ describe('Transfer tests', function () {
       // Check Bob's utxos on the child chain
       let bobUtxos = await childChain.getUtxos(bobAccount.address)
       assert.equal(bobUtxos.length, 2)
-      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount'])
+      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
       assert.equal(bobUtxos[0].amount.toString(), UTXO_AMOUNT)
       assert.equal(bobUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(bobUtxos[1].amount.toString(), UTXO_AMOUNT)
@@ -229,7 +229,7 @@ describe('Transfer tests', function () {
       // Check Alice's utxos on the child chain again
       aliceUtxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(aliceUtxos.length, 2)
-      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount'])
+      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
       assert.equal(aliceUtxos[0].amount.toString(), ALICE_OUTPUT_0)
       assert.equal(aliceUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(aliceUtxos[1].amount.toString(), ALICE_OUTPUT_1)
@@ -238,7 +238,7 @@ describe('Transfer tests', function () {
       // Check Bob's utxos on the child chain again
       bobUtxos = await childChain.getUtxos(bobAccount.address)
       assert.equal(bobUtxos.length, 2)
-      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount'])
+      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
       assert.equal(bobUtxos[0].amount.toString(), BOB_OUTPUT_0)
       assert.equal(bobUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(bobUtxos[1].amount.toString(), BOB_OUTPUT_1)

--- a/packages/integration-tests/test/transferTest.js
+++ b/packages/integration-tests/test/transferTest.js
@@ -471,11 +471,11 @@ describe('Transfer tests', function () {
         fromAddress: aliceAccount.address,
         fromUtxos: utxos,
         fromPrivateKeys: [aliceAccount.privateKey],
-        payment: {
+        payments: [{
           owner: bobAccount.address,
           currency: transaction.ETH_CURRENCY,
           amount: TRANSFER_AMOUNT
-        },
+        }],
         fee: {
           amount: 0,
           currency: transaction.ETH_CURRENCY

--- a/packages/omg-js-childchain/src/childchain.js
+++ b/packages/omg-js-childchain/src/childchain.js
@@ -283,7 +283,7 @@ class ChildChain {
     const txBody = transaction.createTransactionBody({
       fromAddress,
       fromUtxos,
-      payment,
+      payments: [payment],
       fee,
       metadata
     })

--- a/packages/omg-js-childchain/src/childchain.js
+++ b/packages/omg-js-childchain/src/childchain.js
@@ -256,7 +256,7 @@ class ChildChain {
    * @param {string} args.fromAddress the address of the sender
    * @param {Object[]} args.fromUtxos array of utxos to spend
    * @param {string[]} args.fromPrivateKeys private keys of the utxos to spend
-   * @param {Payment} args.payment a payment object
+   * @param {Payment[]} args.payments a payments object
    * @param {Fee} args.fee fee object specifying amount and currency
    * @param {string} [args.metadata] the metadata to include in the transaction. Must be a 32-byte hex string
    * @param {string} args.verifyingContract address of the RootChain contract
@@ -266,7 +266,7 @@ class ChildChain {
     fromAddress,
     fromUtxos,
     fromPrivateKeys,
-    payment,
+    payments,
     fee,
     metadata = null,
     verifyingContract
@@ -275,7 +275,7 @@ class ChildChain {
       fromAddress,
       fromUtxos,
       fromPrivateKeys,
-      payment,
+      payments,
       fee,
       metadata,
       verifyingContract
@@ -283,7 +283,7 @@ class ChildChain {
     const txBody = transaction.createTransactionBody({
       fromAddress,
       fromUtxos,
-      payments: [payment],
+      payments,
       fee,
       metadata
     })

--- a/packages/omg-js-childchain/src/validators/index.js
+++ b/packages/omg-js-childchain/src/validators/index.js
@@ -58,7 +58,7 @@ const sendTransactionSchema = Joi.object({
   fromAddress: validateAddress.required(),
   fromUtxos: Joi.array().items(Joi.object()).required(),
   fromPrivateKeys: Joi.array().items(Joi.string()).required(),
-  payment: validatePayment.required(),
+  payments: validatePayments.required(),
   fee: validateFee.required(),
   metadata: Joi.string().allow(null),
   verifyingContract: validateAddress.required()

--- a/packages/omg-js-childchain/src/validators/index.js
+++ b/packages/omg-js-childchain/src/validators/index.js
@@ -1,5 +1,5 @@
 const Joi = require('@hapi/joi')
-const { validateAddress, validatePayments, validatePayment, validateFee, validateBn } = require('./helpers')
+const { validateAddress, validatePayments, validateFee, validateBn } = require('./helpers')
 
 const childchainConstructorSchema = Joi.object({
   watcherUrl: Joi.string().required(),

--- a/packages/omg-js-util/package-lock.json
+++ b/packages/omg-js-util/package-lock.json
@@ -395,6 +395,11 @@
 				"sha3": "^1.2.2"
 			}
 		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",

--- a/packages/omg-js-util/package.json
+++ b/packages/omg-js-util/package.json
@@ -25,6 +25,7 @@
     "eth-sig-util": "^2.1.1",
     "ethereumjs-util": "^6.0.0",
     "js-sha3": "^0.8.0",
+    "lodash": "^4.17.15",
     "number-to-bn": "^1.7.0",
     "promise-retry": "^1.1.1",
     "rlp": "^2.2.2",

--- a/packages/omg-js-util/src/transaction.js
+++ b/packages/omg-js-util/src/transaction.js
@@ -273,13 +273,13 @@ const transaction = {
     // recalculate change with filtered fromUtxos array, and create outputs (payments + changeOutputs)
     const recalculatedChange = calculateChange(inputs)
     const changeOutputs = recalculatedChange
+      .filter(i => i.change.gt(numberToBN(0)))
       .map(i => ({
         outputType: 1,
         outputGuard: fromAddress,
         currency: i.currency,
         amount: i.change
       }))
-      .filter(i => i.amount.gt(numberToBN(0)))
     const paymentOutputs = payments.map(i => ({
       outputType: 1,
       outputGuard: i.owner,

--- a/packages/omg-js-util/src/transaction.js
+++ b/packages/omg-js-util/src/transaction.js
@@ -18,6 +18,7 @@ global.Buffer = global.Buffer || require('buffer').Buffer
 
 const InvalidArgumentError = require('./InvalidArgumentError')
 const numberToBN = require('number-to-bn')
+const { uniq } = require('lodash')
 const rlp = require('rlp')
 const typedData = require('./typedData')
 const getToSignHash = require('./signHash')
@@ -198,8 +199,8 @@ const transaction = {
   *
   * @param {Object} args an arguments object
   * @param {string} args.fromAddress the address of the sender
-  * @param {Object[]} args.fromUtxos the utxos to use as transaction inputs
-  * @param {Payment} args.payment payment object specifying the output
+  * @param {Object[]} args.fromUtxos the utxos to use as transaction inputs (in order of priority)
+  * @param {Payment[]} args.payments payment objects specifying the outputs
   * @param {Fee} args.fee fee object specifying amount and currency
   * @param {string} args.metadata the metadata to send
   * @return {TransactionBody} transaction object
@@ -209,75 +210,134 @@ const transaction = {
   createTransactionBody: function ({
     fromAddress,
     fromUtxos,
-    payment,
+    payments,
     fee,
     metadata
   }) {
-    validateInputs(fromUtxos)
     validateMetadata(metadata)
     if (!fee.currency) {
       throw new Error('Fee currency not provided.')
     }
-    if (fromUtxos.find(utxo => utxo.currency !== payment.currency && utxo.currency !== fee.currency)) {
-      throw new Error('There are currencies in the utxo array that is not fee or currency.')
-    }
-    const inputArr = fromUtxos.filter(utxo => utxo.currency === payment.currency)
-    const feeArr = fromUtxos.filter(utxo => utxo.currency === fee.currency)
-    const sum = arr => arr.reduce((acc, curr) => acc.add(numberToBN(curr.amount.toString())), numberToBN(0))
-    // Get the total value of the inputs
-    const totalInputValue = sum(inputArr)
-    const totalInputFee = sum(feeArr)
-    const bnAmount = numberToBN(payment.amount)
-    const bnFeeAmount = numberToBN(fee.amount)
-    // Check there is enough in the inputs to cover the amount
-    if (totalInputValue.lt(bnAmount)) {
-      throw new Error(`Insufficient funds for ${bnAmount.toString()}`)
-    }
 
-    // to sender output
-    const outputArr = [{
-      outputType: 1,
-      outputGuard: payment.owner,
-      currency: payment.currency,
-      amount: bnAmount
-    }]
+    // check if fromUtxos has sufficient amounts to cover payments and fees
+    const neededCurrencies = uniq([...payments.map(i => i.currency), fee.currency])
+    const allPayments = [...payments, fee]
 
-    if (fee.currency !== payment.currency && totalInputValue.gt(bnAmount)) {
-      outputArr.push({
-        outputType: 1,
-        outputGuard: fromAddress,
-        currency: payment.currency,
-        amount: totalInputValue.sub(bnAmount)
-      })
-    }
+    const neededVSsupplied = neededCurrencies.map(currency => {
+      const needed = allPayments.reduce((acc, i) => {
+        return i.currency === currency
+          ? acc.add(numberToBN(i.amount))
+          : acc
+      }, numberToBN(0))
+      const supplied = fromUtxos.reduce((acc, i) => {
+        return i.currency === currency
+          ? acc.add(numberToBN(i.amount))
+          : acc
+      }, numberToBN(0))
+      const change = supplied.sub(needed)
+      return {
+        currency,
+        needed,
+        supplied,
+        change
+      }
+    })
 
-    if (fee.currency === payment.currency && totalInputValue.gt(bnAmount.add(bnFeeAmount))) {
-      outputArr.push({
-        outputType: 1,
-        outputGuard: fromAddress,
-        currency: payment.currency,
-        amount: totalInputValue.sub(bnAmount).sub(bnFeeAmount)
-      })
-    }
+    // TODO: remove... just for testing
+    const stringNeeded = neededVSsupplied.map(i => {
+      return {
+        currency: i.currency,
+        needed: i.needed.toString(),
+        supplied: i.supplied.toString(),
+        change: i.change.toString()
+      }
+    })
+    console.log('initialNeeds: ', stringNeeded)
 
-    // fee change
-    if (fee.currency !== payment.currency) {
-      outputArr.push({
-        outputType: 1,
-        outputGuard: fromAddress,
-        currency: fee.currency,
-        amount: totalInputFee.sub(bnFeeAmount)
-      })
+    // compare how much we need vs how much supplied per currency
+    for (const i of neededVSsupplied) {
+      if (i.needed.gt(i.supplied)) {
+        const diff = i.needed.sub(i.supplied)
+        throw new Error(`Insufficient funds. Needs ${diff.toString()} more of ${i.currency} to cover payments and fees`)
+      }
     }
 
-    const txBody = {
-      inputs: fromUtxos,
-      outputs: outputArr,
-      txData: 0,
-      metadata
-    }
+    // get inputs array by filtering fromUtxos actually used (respecting order)
+    const _needed = [...neededVSsupplied]
+    const inputs = fromUtxos.filter(fromUtxo => {
+      const foundIndex = _needed.findIndex(i => i.currency === fromUtxo.currency)
+      const foundItem = _needed.find(i => i.currency === fromUtxo.currency)
+      if (!foundItem || foundItem.needed.lte(numberToBN(0))) {
+        return false
+      }
+      const diff = foundItem.needed.sub(numberToBN(fromUtxo.amount))
+      _needed[foundIndex] = {
+        ...foundItem,
+        needed: diff
+      }
+      return true
+    })
+    validateInputs(inputs)
+    console.log('_needed: ', _needed)
 
-    return txBody
+    // recalculate change with filtered fromUtxos array, and create outputs
+
+    // const inputArr = fromUtxos.filter(utxo => utxo.currency === payment.currency)
+    // const feeArr = fromUtxos.filter(utxo => utxo.currency === fee.currency)
+    // const sum = arr => arr.reduce((acc, curr) => acc.add(numberToBN(curr.amount.toString())), numberToBN(0))
+    // // Get the total value of the inputs
+    // const totalInputValue = sum(inputArr)
+    // const totalInputFee = sum(feeArr)
+    // const bnAmount = numberToBN(payment.amount)
+    // const bnFeeAmount = numberToBN(fee.amount)
+    // // Check there is enough in the inputs to cover the amount
+    // if (totalInputValue.lt(bnAmount)) {
+    //   throw new Error(`Insufficient funds for ${bnAmount.toString()}`)
+    // }
+
+    // // to sender output
+    // const outputArr = [{
+    //   outputType: 1,
+    //   outputGuard: payment.owner,
+    //   currency: payment.currency,
+    //   amount: bnAmount
+    // }]
+
+    // if (fee.currency !== payment.currency && totalInputValue.gt(bnAmount)) {
+    //   outputArr.push({
+    //     outputType: 1,
+    //     outputGuard: fromAddress,
+    //     currency: payment.currency,
+    //     amount: totalInputValue.sub(bnAmount)
+    //   })
+    // }
+
+    // if (fee.currency === payment.currency && totalInputValue.gt(bnAmount.add(bnFeeAmount))) {
+    //   outputArr.push({
+    //     outputType: 1,
+    //     outputGuard: fromAddress,
+    //     currency: payment.currency,
+    //     amount: totalInputValue.sub(bnAmount).sub(bnFeeAmount)
+    //   })
+    // }
+
+    // // fee change
+    // if (fee.currency !== payment.currency) {
+    //   outputArr.push({
+    //     outputType: 1,
+    //     outputGuard: fromAddress,
+    //     currency: fee.currency,
+    //     amount: totalInputFee.sub(bnFeeAmount)
+    //   })
+    // }
+
+    // const txBody = {
+    //   inputs: fromUtxos,
+    //   outputs: outputArr,
+    //   txData: 0,
+    //   metadata
+    // }
+    // return txBody
   },
 
   /**

--- a/packages/omg-js-util/src/transaction.js
+++ b/packages/omg-js-util/src/transaction.js
@@ -272,12 +272,14 @@ const transaction = {
 
     // recalculate change with filtered fromUtxos array, and create outputs (payments + changeOutputs)
     const recalculatedChange = calculateChange(inputs)
-    const changeOutputs = recalculatedChange.map(i => ({
-      outputType: 1,
-      outputGuard: fromAddress,
-      currency: i.currency,
-      amount: i.change
-    }))
+    const changeOutputs = recalculatedChange
+      .map(i => ({
+        outputType: 1,
+        outputGuard: fromAddress,
+        currency: i.currency,
+        amount: i.change
+      }))
+      .filter(i => i.amount.gt(numberToBN(0)))
     const paymentOutputs = payments.map(i => ({
       outputType: 1,
       outputGuard: i.owner,

--- a/packages/omg-js-util/test/createTransactionBodyTest.js
+++ b/packages/omg-js-util/test/createTransactionBodyTest.js
@@ -465,7 +465,6 @@ describe('createTransactionBody', function () {
       },
       metadata: undefined
     })
-    console.log(txBody)
     assert.equal(txBody.inputs.length, 2)
     assert.equal(txBody.outputs.length, 1)
 

--- a/packages/omg-js-util/test/createTransactionBodyTest.js
+++ b/packages/omg-js-util/test/createTransactionBodyTest.js
@@ -3,6 +3,47 @@ const numberToBN = require('number-to-bn')
 const assert = require('chai').assert
 
 describe('createTransactionBody', function () {
+  it.only('toto', function () {
+    const txBody = transaction.createTransactionBody({
+      fromAddress: '0xf4ebbe787311bb955bb353b7a4d8b97af8ed1c9b',
+      fromUtxos: [
+        {
+          txindex: 0,
+          oindex: 0,
+          currency: transaction.ETH_CURRENCY,
+          blknum: 2,
+          amount: 60
+        },
+        {
+          txindex: 0,
+          oindex: 0,
+          currency: '0x123',
+          blknum: 2,
+          amount: 10
+        }
+      ],
+      payments: [
+        {
+          owner: '0x3272ee86d8192f59261960c9ae186063c8c9041f',
+          amount: 50,
+          currency: transaction.ETH_CURRENCY
+        },
+        {
+          owner: '0x3272ee86d8192f59261960c9ae186063c8c9041f',
+          amount: 10,
+          currency: '0x123'
+        }
+      ],
+      fee: {
+        amount: 0,
+        currency: transaction.ETH_CURRENCY
+      },
+      metadata: undefined
+    })
+
+    console.log(txBody)
+  })
+
   it('should create a transaction body from one input and give change', function () {
     const fromAddress = '0xf4ebbe787311bb955bb353b7a4d8b97af8ed1c9b'
     const fromUtxos = [
@@ -21,11 +62,11 @@ describe('createTransactionBody', function () {
     const txBody = transaction.createTransactionBody({
       fromAddress,
       fromUtxos,
-      payment: {
+      payments: [{
         owner: toAddress,
         amount: toAmount,
         currency: transaction.ETH_CURRENCY
-      },
+      }],
       fee: {
         amount: 0,
         currency: transaction.ETH_CURRENCY
@@ -70,11 +111,11 @@ describe('createTransactionBody', function () {
     const txBody = transaction.createTransactionBody({
       fromAddress,
       fromUtxos,
-      payment: {
+      payments: [{
         owner: toAddress,
         amount: toAmount,
         currency: transaction.ETH_CURRENCY
-      },
+      }],
       fee: {
         amount: 0,
         currency: transaction.ETH_CURRENCY
@@ -119,11 +160,11 @@ describe('createTransactionBody', function () {
     const txBody = transaction.createTransactionBody({
       fromAddress,
       fromUtxos,
-      payment: {
+      payments: [{
         owner: toAddress,
         amount: toAmount,
         currency: transaction.ETH_CURRENCY
-      },
+      }],
       fee: {
         amount: 0,
         currency: transaction.ETH_CURRENCY
@@ -153,11 +194,11 @@ describe('createTransactionBody', function () {
     const txBody = transaction.createTransactionBody({
       fromAddress,
       fromUtxos,
-      payment: {
+      payments: [{
         owner: toAddress,
         amount: toAmount,
         currency: transaction.ETH_CURRENCY
-      },
+      }],
       fee: {
         amount: 0,
         currency: transaction.ETH_CURRENCY
@@ -195,11 +236,11 @@ describe('createTransactionBody', function () {
     const txBody = transaction.createTransactionBody({
       fromAddress,
       fromUtxos,
-      payment: {
+      payments: [{
         owner: toAddress,
         amount: toSendErc20Amount,
         currency: fakeErc20
-      },
+      }],
       fee: {
         amount: 50,
         currency: transaction.ETH_CURRENCY
@@ -250,11 +291,11 @@ describe('createTransactionBody', function () {
     const txBody = transaction.createTransactionBody({
       fromAddress,
       fromUtxos,
-      payment: {
+      payments: [{
         owner: toAddress,
         amount: toSendEthAmount,
         currency: transaction.ETH_CURRENCY
-      },
+      }],
       fee: {
         amount: 50,
         currency: fakeErc20
@@ -299,11 +340,11 @@ describe('createTransactionBody', function () {
         transaction.createTransactionBody({
           fromAddress,
           fromUtxos,
-          payment: {
+          payments: [{
             owner: toAddress,
             amount: toAmount,
             currency: transaction.ETH_CURRENCY
-          },
+          }],
           fee: {
             amount: 0,
             currency: transaction.ETH_CURRENCY
@@ -349,11 +390,11 @@ describe('createTransactionBody', function () {
         transaction.createTransactionBody({
           fromAddress,
           fromUtxos,
-          payment: {
+          payments: [{
             owner: toAddress,
             amount: toAmount,
             currency: transaction.ETH_CURRENCY
-          },
+          }],
           fee: {
             amount: 0,
             currency: transaction.ETH_CURRENCY

--- a/packages/omg-js-util/test/createTransactionBodyTest.js
+++ b/packages/omg-js-util/test/createTransactionBodyTest.js
@@ -34,15 +34,10 @@ describe('createTransactionBody', function () {
           owner: '0x3272ee86d8192f59261960c9ae186063c8c9041f',
           amount: 50,
           currency: transaction.ETH_CURRENCY
-        },
-        {
-          owner: '0x3272ee86d8192f59261960c9ae186063c8c9041f',
-          amount: 10,
-          currency: '0x123'
         }
       ],
       fee: {
-        amount: 0,
+        amount: 5,
         currency: transaction.ETH_CURRENCY
       },
       metadata: undefined

--- a/packages/omg-js-util/test/createTransactionBodyTest.js
+++ b/packages/omg-js-util/test/createTransactionBodyTest.js
@@ -3,49 +3,6 @@ const numberToBN = require('number-to-bn')
 const assert = require('chai').assert
 
 describe('createTransactionBody', function () {
-  it.only('toto', function () {
-    const txBody = transaction.createTransactionBody({
-      fromAddress: '0xf4ebbe787311bb955bb353b7a4d8b97af8ed1c9b',
-      fromUtxos: [
-        {
-          txindex: 0,
-          oindex: 0,
-          currency: transaction.ETH_CURRENCY,
-          blknum: 2,
-          amount: 60
-        },
-        {
-          txindex: 0,
-          oindex: 0,
-          currency: transaction.ETH_CURRENCY,
-          blknum: 2,
-          amount: 60
-        },
-        {
-          txindex: 0,
-          oindex: 0,
-          currency: '0x123',
-          blknum: 2,
-          amount: 10
-        }
-      ],
-      payments: [
-        {
-          owner: '0x3272ee86d8192f59261960c9ae186063c8c9041f',
-          amount: 50,
-          currency: transaction.ETH_CURRENCY
-        }
-      ],
-      fee: {
-        amount: 5,
-        currency: transaction.ETH_CURRENCY
-      },
-      metadata: undefined
-    })
-
-    console.log(txBody)
-  })
-
   it('should create a transaction body from one input and give change', function () {
     const fromAddress = '0xf4ebbe787311bb955bb353b7a4d8b97af8ed1c9b'
     const fromUtxos = [
@@ -76,14 +33,17 @@ describe('createTransactionBody', function () {
       metadata: undefined
     })
     assert.equal(txBody.outputs.length, 2)
-    assert.equal(txBody.outputs[0].outputGuard, toAddress)
-    assert.equal(txBody.outputs[0].amount.toString(), toAmount.toString())
-    assert.equal(txBody.outputs[1].outputGuard, fromAddress)
+    assert.equal(txBody.inputs.length, 1)
+
+    const paymentOutput = txBody.outputs.find(i => i.outputGuard === toAddress)
+    const changeOutput = txBody.outputs.find(i => i.outputGuard === fromAddress)
+
+    assert.equal(paymentOutput.amount.toString(), toAmount.toString())
     const expectedChange = numberToBN(fromUtxos[0].amount).sub(
       numberToBN(toAmount)
     )
     assert.equal(
-      txBody.outputs[1].amount.toString(),
+      changeOutput.amount.toString(),
       expectedChange.toString()
     )
   })
@@ -124,20 +84,23 @@ describe('createTransactionBody', function () {
       },
       metadata: undefined
     })
+    assert.equal(txBody.inputs.length, 2)
     assert.equal(txBody.outputs.length, 2)
-    assert.equal(txBody.outputs[0].outputGuard, toAddress)
-    assert.equal(txBody.outputs[0].amount.toString(), toAmount.toString())
-    assert.equal(txBody.outputs[1].outputGuard, fromAddress)
+
+    const paymentOutput = txBody.outputs.find(i => i.outputGuard === toAddress)
+    const changeOutput = txBody.outputs.find(i => i.outputGuard === fromAddress)
+
+    assert.equal(paymentOutput.amount.toString(), toAmount.toString())
     const expectedChange = numberToBN(fromUtxos[0].amount)
       .add(numberToBN(fromUtxos[1].amount))
       .sub(numberToBN(toAmount))
     assert.equal(
-      txBody.outputs[1].amount.toString(),
+      changeOutput.amount.toString(),
       expectedChange.toString()
     )
   })
 
-  it('should create a transaction body from two inputs for the exact amount, and not give change', function () {
+  it.only('should create a transaction body from two inputs for the exact amount, and not give change', function () {
     const fromAddress = '0xf4ebbe787311bb955bb353b7a4d8b97af8ed1c9b'
     const fromUtxos = [
       {
@@ -173,6 +136,8 @@ describe('createTransactionBody', function () {
       },
       metadata: undefined
     })
+    console.log(txBody)
+
     assert.equal(txBody.outputs.length, 1)
     assert.equal(txBody.outputs[0].outputGuard, toAddress)
     assert.equal(txBody.outputs[0].amount.toString(), toAmount.toString())

--- a/packages/omg-js-util/test/createTransactionBodyTest.js
+++ b/packages/omg-js-util/test/createTransactionBodyTest.js
@@ -17,6 +17,13 @@ describe('createTransactionBody', function () {
         {
           txindex: 0,
           oindex: 0,
+          currency: transaction.ETH_CURRENCY,
+          blknum: 2,
+          amount: 60
+        },
+        {
+          txindex: 0,
+          oindex: 0,
           currency: '0x123',
           blknum: 2,
           amount: 10


### PR DESCRIPTION
Improve the functionality of `transaction.createTransactionBody` which implies improving the same on `childchain.sendTransaction`

- [205](https://github.com/omisego/omg-js/issues/205) accept multiple payments
- [204](https://github.com/omisego/omg-js/issues/204) improve documentation on the many different ways we provide to create/send transactions

`createTransactionBody` improvements
- can pass any length of `fromUtxos` and will disregard unused utxos
- will respect order of preference of `fromUtxos`... useful if merging utxos 
- better errors and more tests