### PR TITLE
219 - Get usable data from the exit queue

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2369,7 +2369,7 @@ Should be called periodically to see if there are any byzantine_events to be act
 
   <p>Retrieves the exit queue for a particular token</p>
 
-    <div class='pre p1 fill-light mt0'>getExitQueue(token: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>></div>
+    <div class='pre p1 fill-light mt0'>getExitQueue(token: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>>></div>
   
   
 
@@ -2401,8 +2401,8 @@ Should be called periodically to see if there are any byzantine_events to be act
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>></code>:
-        promise that resolves with the exit queue of the token (as priorities)
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>>></code>:
+        promise that resolves with the exit queue
 
       
     

--- a/packages/omg-js-rootchain/src/rootchain.js
+++ b/packages/omg-js-rootchain/src/rootchain.js
@@ -181,14 +181,20 @@ class RootChain {
     const address = await this.plasmaContract.methods.exitsQueues(hashed).call()
     const contract = getContract(this.web3, priorityQueueAbi.abi, address)
     const rawExitQueue = await contract.methods.heapList().call()
+    // remove the first element since it is always 0 (because heap lists start from index 1)
     const exitQueuePriorities = rawExitQueue.slice(1)
 
     const exitQueue = exitQueuePriorities.map(priority => {
       const asBN = new BN(priority)
+      // turn the uint256 priority into binary
       const binary = asBN.toString(2, 256)
 
+      // split the bits into their necessary data
+      // https://github.com/omisego/plasma-contracts/blob/master/plasma_framework/contracts/src/framework/utils/ExitPriority.sol#L16
       const exitableAtBinary = binary.substr(0, 42)
       const exitIdBinary = binary.substr(96, 160)
+
+      // use BN to turn binary back into the format we want
       const exitableAt = new BN(exitableAtBinary, 2)
       const exitId = new BN(exitIdBinary, 2)
 


### PR DESCRIPTION
`getExitQueue()` now returns more data about the exit queue 🕺 
[issue 219](https://github.com/omisego/omg-js/issues/219)

```
const exitQueue = [
  { exitId, exitableAt }
]
```

so knowing your exitId can tell you the exact position your exit is sitting in the queue.
also the `exitableAt` returned is consistent with the `getExitTime` local calculation the lib already does, only now you just need to know your exitId to retrieve that... which is awesome.
