### PR TITLE
Hotfix getexitqueue

### DIFF
--- a/packages/omg-js-rootchain/src/rootchain.js
+++ b/packages/omg-js-rootchain/src/rootchain.js
@@ -181,31 +181,35 @@ class RootChain {
     const address = await this.plasmaContract.methods.exitsQueues(hashed).call()
     const contract = getContract(this.web3, priorityQueueAbi.abi, address)
     const rawExitQueue = await contract.methods.heapList().call()
-    // remove the first element since it is always 0 (because heap lists start from index 1)
-    const exitQueuePriorities = rawExitQueue.slice(1)
 
-    const exitQueue = exitQueuePriorities.map(priority => {
-      const asBN = new BN(priority)
-      // turn the uint256 priority into binary
-      const binary = asBN.toString(2, 256)
+    if (rawExitQueue && rawExitQueue.length) {
+      // remove the first element since it is always 0 (because heap lists start from index 1)
+      const exitQueuePriorities = rawExitQueue.slice(1)
+      const exitQueue = exitQueuePriorities.map(_priority => {
+        const priority = _priority.toString()
+        const asBN = new BN(priority)
+        // turn the uint256 priority into binary
+        const binary = asBN.toString(2, 256)
 
-      // split the bits into their necessary data
-      // https://github.com/omisego/plasma-contracts/blob/master/plasma_framework/contracts/src/framework/utils/ExitPriority.sol#L16
-      const exitableAtBinary = binary.substr(0, 42)
-      const exitIdBinary = binary.substr(96, 160)
+        // split the bits into their necessary data
+        // https://github.com/omisego/plasma-contracts/blob/master/plasma_framework/contracts/src/framework/utils/ExitPriority.sol#L16
+        const exitableAtBinary = binary.substr(0, 42)
+        const exitIdBinary = binary.substr(96, 160)
 
-      // use BN to turn binary back into the format we want
-      const exitableAt = new BN(exitableAtBinary, 2)
-      const exitId = new BN(exitIdBinary, 2)
+        // use BN to turn binary back into the format we want
+        const exitableAt = new BN(exitableAtBinary, 2)
+        const exitId = new BN(exitIdBinary, 2)
 
-      return {
-        priority,
-        exitableAt: exitableAt.toString(),
-        exitId: exitId.toString()
-      }
-    })
-
-    return exitQueue
+        return {
+          priority,
+          exitableAt: exitableAt.toString(),
+          exitId: exitId.toString()
+        }
+      })
+      return exitQueue
+    } else {
+      return []
+    }
   }
 
   /**


### PR DESCRIPTION
when trying this out on an app, web3 was returning priorities as strings in node but on the browser they were returned as BigNumber objects which would throw since it couldnt parse it as BN.js... so enforcing it as strings...