### PR TITLE
Update for elixir-omg sha a43605e

### DIFF
--- a/packages/integration-tests/test/depositTest.js
+++ b/packages/integration-tests/test/depositTest.js
@@ -117,7 +117,7 @@ describe('depositTest.js (ci-enabled)', function () {
       // THe account should have one utxo on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 1)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount.toString(), TEST_AMOUNT)
       assert.equal(utxos[0].currency, transaction.ETH_CURRENCY)
     })
@@ -181,7 +181,7 @@ describe('depositTest.js (ci-enabled)', function () {
       // THe account should have one utxo on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 1)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount.toString(), TEST_AMOUNT)
       assert.equal(utxos[0].currency.toLowerCase(), config.erc20_contract_address.toLowerCase())
     })

--- a/packages/integration-tests/test/inFlightExitChallengeTest.js
+++ b/packages/integration-tests/test/inFlightExitChallengeTest.js
@@ -267,12 +267,11 @@ describe('inFlightExitChallengeTest.js', function () {
 
       // Get Bob's ETH balance
       const bobEthBalance = await web3.eth.getBalance(bobAccount.address)
-      // Bob's IFE was not successful, so he loses his exit bond.
-      // INTIIAL_BOB_AMOUNT - INFLIGHT_EXIT_BOND - PIGGYBACK_BOND - gas spent
+      // Bob's IFE was not successful, so he loses his exit bond, but gets his piggyback bond back
+      // INTIIAL_BOB_AMOUNT - INFLIGHT_EXIT_BOND - gas spent
       const expected = web3.utils
         .toBN(INTIIAL_BOB_RC_AMOUNT)
         .sub(web3.utils.toBN(bonds.inflightExit))
-        .sub(web3.utils.toBN(bonds.piggyback))
         .sub(bobSpentOnGas)
       assert.equal(bobEthBalance.toString(), expected.toString())
 

--- a/packages/integration-tests/test/inFlightExitChallengeTest.js
+++ b/packages/integration-tests/test/inFlightExitChallengeTest.js
@@ -494,12 +494,11 @@ describe('inFlightExitChallengeTest.js', function () {
       const { bonds } = await rootChain.getPaymentExitGame()
       // Get Bob's ETH balance
       const bobEthBalance = await web3.eth.getBalance(bobAccount.address)
-      // Bob's IFE was not successful, so he loses his exit bond.
-      // INTIIAL_BOB_AMOUNT - INFLIGHT_EXIT_BOND - PIGGYBACK_BOND - gas spent
+      // Bob's IFE was not successful, so he loses his exit bond, but gets back his piggyback bond.
+      // INTIIAL_BOB_AMOUNT - INFLIGHT_EXIT_BOND - gas spent
       const expected = web3.utils
         .toBN(INTIIAL_BOB_RC_AMOUNT)
         .sub(web3.utils.toBN(bonds.inflightExit))
-        .sub(web3.utils.toBN(bonds.piggyback))
         .sub(bobSpentOnGas)
       assert.equal(bobEthBalance.toString(), expected.toString())
 

--- a/packages/integration-tests/test/standardExitTest.js
+++ b/packages/integration-tests/test/standardExitTest.js
@@ -358,7 +358,8 @@ describe('standardExitTest.js', function () {
         'blknum',
         'amount',
         'creating_txhash',
-        'spending_txhash'
+        'spending_txhash',
+        'otype'
       ])
       assert.equal(utxos[0].amount, INTIIAL_ALICE_AMOUNT_ERC20)
       assert.equal(

--- a/packages/integration-tests/test/transferTest.js
+++ b/packages/integration-tests/test/transferTest.js
@@ -68,7 +68,7 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check utxos on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 1)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount.toString(), INTIIAL_ALICE_AMOUNT)
       assert.equal(utxos[0].currency, transaction.ETH_CURRENCY)
 
@@ -145,7 +145,7 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check Alice's utxos on the child chain
       let aliceUtxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(aliceUtxos.length, 2)
-      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(aliceUtxos[0].amount.toString(), UTXO_AMOUNT)
       assert.equal(aliceUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(aliceUtxos[1].amount.toString(), UTXO_AMOUNT)
@@ -154,7 +154,7 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check Bob's utxos on the child chain
       let bobUtxos = await childChain.getUtxos(bobAccount.address)
       assert.equal(bobUtxos.length, 2)
-      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(bobUtxos[0].amount.toString(), UTXO_AMOUNT)
       assert.equal(bobUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(bobUtxos[1].amount.toString(), UTXO_AMOUNT)
@@ -222,7 +222,7 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check Alice's utxos on the child chain again
       aliceUtxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(aliceUtxos.length, 2)
-      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(aliceUtxos[0].amount.toString(), ALICE_OUTPUT_0)
       assert.equal(aliceUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(aliceUtxos[1].amount.toString(), ALICE_OUTPUT_1)
@@ -231,7 +231,7 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check Bob's utxos on the child chain again
       bobUtxos = await childChain.getUtxos(bobAccount.address)
       assert.equal(bobUtxos.length, 2)
-      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(bobUtxos[0].amount.toString(), BOB_OUTPUT_0)
       assert.equal(bobUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(bobUtxos[1].amount.toString(), BOB_OUTPUT_1)
@@ -273,7 +273,7 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check utxos on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 2)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
 
       const erc20Utxo = utxos.find(utxo => utxo.currency === ERC20_CURRENCY)
       const ethUtxo = utxos.find(utxo => utxo.currency === transaction.ETH_CURRENCY)
@@ -356,7 +356,7 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check utxos on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 2)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount, INTIIAL_ALICE_AMOUNT_ETH)
       assert.equal(utxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(utxos[1].amount, INTIIAL_ALICE_AMOUNT_ERC20)
@@ -446,7 +446,7 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check utxos on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 1)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash'])
+      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount.toString(), INTIIAL_ALICE_AMOUNT)
       assert.equal(utxos[0].currency, transaction.ETH_CURRENCY)
 

--- a/packages/omg-js-childchain/src/validators/index.js
+++ b/packages/omg-js-childchain/src/validators/index.js
@@ -38,7 +38,8 @@ const getExitDataSchema = Joi.object({
   txindex: Joi.number().integer(),
   utxo_pos: validateAmount,
   spending_txhash: [Joi.string(), Joi.allow(null)],
-  creating_txhash: [Joi.string(), Joi.allow(null)]
+  creating_txhash: [Joi.string(), Joi.allow(null)],
+  otype: Joi.number().integer()
 })
 
 const getChallengeDataSchema = Joi.object({


### PR DESCRIPTION
Some changes due to pr in issue [here](https://github.com/omisego/omg-js/issues/246) was causing validation to fail.

Also with the new contract `7c3f796` piggy bonds are returned correctly so fix required in ife test
specifically: https://github.com/omisego/plasma-contracts/issues/584

This pr will make us up to date with the shas for the ODP release