### PR TITLE
Fix strict input validation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7033,6 +7033,12 @@ This method decodes a string that was encoded with encodeMetadata().</p>
         </div>
       
         <div class='space-bottom0'>
+          <span class='code bold'>creating_txhash</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
           <span class='code bold'>currency</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
           
           
@@ -7045,7 +7051,19 @@ This method decodes a string that was encoded with encodeMetadata().</p>
         </div>
       
         <div class='space-bottom0'>
+          <span class='code bold'>otype</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
           <span class='code bold'>owner</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>spending_txhash</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
           
           
         </div>

--- a/packages/integration-tests/parallel-test.js
+++ b/packages/integration-tests/parallel-test.js
@@ -27,7 +27,8 @@ const mochaParallel = new MochaParallel({
   slow: 0,
   useColors: true,
   fullStackTrace: true,
-  reporter: 'list'
+  reporter: 'list',
+  retries: 1
 })
 
 const allFiles = fs.readdirSync(`${__dirname}/test/`)

--- a/packages/integration-tests/test/challengeExitTest.js
+++ b/packages/integration-tests/test/challengeExitTest.js
@@ -27,7 +27,7 @@ const assert = chai.assert
 const path = require('path')
 const faucetName = path.basename(__filename)
 
-describe.only('challengeExitTest.js', function () {
+describe('challengeExitTest.js', function () {
   const web3 = new Web3(new Web3.providers.HttpProvider(config.eth_node))
   const childChain = new ChildChain({ watcherUrl: config.watcher_url, watcherProxyUrl: config.watcher_proxy_url })
   const rootChain = new RootChain({ web3, plasmaContractAddress: config.plasmaframework_contract_address })

--- a/packages/integration-tests/test/challengeExitTest.js
+++ b/packages/integration-tests/test/challengeExitTest.js
@@ -27,7 +27,7 @@ const assert = chai.assert
 const path = require('path')
 const faucetName = path.basename(__filename)
 
-describe('challengeExitTest.js', function () {
+describe.only('challengeExitTest.js', function () {
   const web3 = new Web3(new Web3.providers.HttpProvider(config.eth_node))
   const childChain = new ChildChain({ watcherUrl: config.watcher_url, watcherProxyUrl: config.watcher_proxy_url })
   const rootChain = new RootChain({ web3, plasmaContractAddress: config.plasmaframework_contract_address })
@@ -128,7 +128,7 @@ describe('challengeExitTest.js', function () {
 
       // ...and challenges the exit
       const challengeData = await childChain.getChallengeData(invalidExit.details.utxo_pos)
-      assert.hasAllKeys(challengeData, ['input_index', 'exit_id', 'exiting_tx', 'sig', 'txbytes'])
+      assert.containsAllKeys(challengeData, ['input_index', 'exit_id', 'exiting_tx', 'sig', 'txbytes'])
       let receipt = await rootChain.challengeStandardExit({
         standardExitId: challengeData.exit_id,
         exitingTx: challengeData.exiting_tx,

--- a/packages/integration-tests/test/challengeInFlightExitInputSpentTest.js
+++ b/packages/integration-tests/test/challengeInFlightExitInputSpentTest.js
@@ -122,7 +122,7 @@ describe('challengeInFlightExitInputSpentTest.js', function () {
 
       // Get the exit data
       const exitData = await childChain.inFlightExitGetData(bobTx)
-      assert.hasAllKeys(exitData, [
+      assert.containsAllKeys(exitData, [
         'in_flight_tx',
         'in_flight_tx_sigs',
         'input_txs',

--- a/packages/integration-tests/test/decodeTxBytesTest.js
+++ b/packages/integration-tests/test/decodeTxBytesTest.js
@@ -79,7 +79,7 @@ describe('decodeTxBytesTest.js (ci-enabled)', function () {
       // Get the exit data
       const utxoToExit = aliceUtxos[0]
       const exitData = await childChain.getExitData(utxoToExit)
-      assert.hasAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
+      assert.containsAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
       assert.deepEqual(
         {
           txType: 1,

--- a/packages/integration-tests/test/depositTest.js
+++ b/packages/integration-tests/test/depositTest.js
@@ -117,7 +117,6 @@ describe('depositTest.js (ci-enabled)', function () {
       // THe account should have one utxo on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 1)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount.toString(), TEST_AMOUNT)
       assert.equal(utxos[0].currency, transaction.ETH_CURRENCY)
     })
@@ -181,7 +180,6 @@ describe('depositTest.js (ci-enabled)', function () {
       // THe account should have one utxo on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 1)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount.toString(), TEST_AMOUNT)
       assert.equal(utxos[0].currency.toLowerCase(), config.erc20_contract_address.toLowerCase())
     })

--- a/packages/integration-tests/test/getExitQueueTest.js
+++ b/packages/integration-tests/test/getExitQueueTest.js
@@ -97,7 +97,7 @@ describe('getExitQueueTest.js', function () {
     // Get the exit data
     const utxoToExit = aliceUtxos[0]
     const exitData = await childChain.getExitData(utxoToExit)
-    assert.hasAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
+    assert.containsAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
 
     const standardExitReceipt = await rootChain.startStandardExit({
       utxoPos: exitData.utxo_pos,

--- a/packages/integration-tests/test/inFlightExitChallengeResponseTest.js
+++ b/packages/integration-tests/test/inFlightExitChallengeResponseTest.js
@@ -98,7 +98,7 @@ describe('inFlightExitChallengeResponseTest.js', function () {
 
       // Get the exit data
       const exitData = await childChain.inFlightExitGetData(bobTx)
-      assert.hasAllKeys(exitData, ['in_flight_tx', 'in_flight_tx_sigs', 'input_txs', 'input_txs_inclusion_proofs', 'input_utxos_pos'])
+      assert.containsAllKeys(exitData, ['in_flight_tx', 'in_flight_tx_sigs', 'input_txs', 'input_txs_inclusion_proofs', 'input_utxos_pos'])
 
       // Starts the in-flight exit
       const ifeExitReceipt = await rootChain.startInFlightExit({

--- a/packages/integration-tests/test/inFlightExitChallengeTest.js
+++ b/packages/integration-tests/test/inFlightExitChallengeTest.js
@@ -115,7 +115,7 @@ describe('inFlightExitChallengeTest.js', function () {
 
       // Get the exit data
       const exitData = await childChain.inFlightExitGetData(bobTx)
-      assert.hasAllKeys(exitData, [
+      assert.containsAllKeys(exitData, [
         'in_flight_tx',
         'in_flight_tx_sigs',
         'input_txs',
@@ -212,7 +212,7 @@ describe('inFlightExitChallengeTest.js', function () {
         inflightExit.txbytes
       )
       console.log('Got competitor')
-      assert.hasAllKeys(competitor, [
+      assert.containsAllKeys(competitor, [
         'in_flight_txbytes',
         'in_flight_input_index',
         'competing_txbytes',
@@ -364,7 +364,7 @@ describe('inFlightExitChallengeTest.js', function () {
 
       // Get the exit data
       const exitData = await childChain.inFlightExitGetData(bobTx)
-      assert.hasAllKeys(exitData, [
+      assert.containsAllKeys(exitData, [
         'in_flight_tx',
         'in_flight_tx_sigs',
         'input_txs',

--- a/packages/integration-tests/test/inFlightExitTest.js
+++ b/packages/integration-tests/test/inFlightExitTest.js
@@ -28,7 +28,7 @@ const assert = chai.assert
 const path = require('path')
 const faucetName = path.basename(__filename)
 
-describe.only('inFlightExitTest.js', function () {
+describe('inFlightExitTest.js', function () {
   const web3 = new Web3(new Web3.providers.HttpProvider(config.eth_node))
   const childChain = new ChildChain({ watcherUrl: config.watcher_url, watcherProxyUrl: config.watcher_proxy_url })
   const rootChain = new RootChain({ web3, plasmaContractAddress: config.plasmaframework_contract_address })

--- a/packages/integration-tests/test/inFlightExitTest.js
+++ b/packages/integration-tests/test/inFlightExitTest.js
@@ -28,7 +28,7 @@ const assert = chai.assert
 const path = require('path')
 const faucetName = path.basename(__filename)
 
-describe('inFlightExitTest.js', function () {
+describe.only('inFlightExitTest.js', function () {
   const web3 = new Web3(new Web3.providers.HttpProvider(config.eth_node))
   const childChain = new ChildChain({ watcherUrl: config.watcher_url, watcherProxyUrl: config.watcher_proxy_url })
   const rootChain = new RootChain({ web3, plasmaContractAddress: config.plasmaframework_contract_address })
@@ -103,7 +103,7 @@ describe('inFlightExitTest.js', function () {
 
       // Get the exit data
       const exitData = await childChain.inFlightExitGetData(txbytes)
-      assert.hasAllKeys(exitData, [
+      assert.containsAllKeys(exitData, [
         'in_flight_tx',
         'in_flight_tx_sigs',
         'input_txs',
@@ -230,7 +230,7 @@ describe('inFlightExitTest.js', function () {
 
       // Get the exit data
       const exitData = await childChain.inFlightExitGetData(bobTx)
-      assert.hasAllKeys(exitData, [
+      assert.containsAllKeys(exitData, [
         'in_flight_tx',
         'in_flight_tx_sigs',
         'input_txs',

--- a/packages/integration-tests/test/standardExitTest.js
+++ b/packages/integration-tests/test/standardExitTest.js
@@ -349,18 +349,6 @@ describe('standardExitTest.js', function () {
       // Check utxos on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 1)
-      assert.hasAllKeys(utxos[0], [
-        'utxo_pos',
-        'txindex',
-        'owner',
-        'oindex',
-        'currency',
-        'blknum',
-        'amount',
-        'creating_txhash',
-        'spending_txhash',
-        'otype'
-      ])
       assert.equal(utxos[0].amount, INTIIAL_ALICE_AMOUNT_ERC20)
       assert.equal(
         utxos[0].currency.toLowerCase(),

--- a/packages/integration-tests/test/standardExitTest.js
+++ b/packages/integration-tests/test/standardExitTest.js
@@ -88,7 +88,7 @@ describe('standardExitTest.js', function () {
       // Get the exit data
       const utxoToExit = aliceUtxos[0]
       const exitData = await childChain.getExitData(utxoToExit)
-      assert.hasAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
+      assert.containsAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
 
       const standardExitReceipt = await rootChain.startStandardExit({
         utxoPos: exitData.utxo_pos,
@@ -229,7 +229,7 @@ describe('standardExitTest.js', function () {
       // Get the exit data
       const utxoToExit = bobUtxos[0]
       const exitData = await childChain.getExitData(utxoToExit)
-      assert.hasAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
+      assert.containsAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
 
       const startStandardExitReceipt = await rootChain.startStandardExit({
         utxoPos: exitData.utxo_pos,
@@ -358,7 +358,7 @@ describe('standardExitTest.js', function () {
       // Get the exit data
       const utxoToExit = utxos[0]
       const exitData = await childChain.getExitData(utxoToExit)
-      assert.hasAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
+      assert.containsAllKeys(exitData, ['txbytes', 'proof', 'utxo_pos'])
 
       const standardExitReceipt = await rootChain.startStandardExit({
         utxoPos: exitData.utxo_pos,

--- a/packages/integration-tests/test/transferTest.js
+++ b/packages/integration-tests/test/transferTest.js
@@ -68,7 +68,6 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check utxos on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 1)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount.toString(), INTIIAL_ALICE_AMOUNT)
       assert.equal(utxos[0].currency, transaction.ETH_CURRENCY)
 
@@ -145,7 +144,6 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check Alice's utxos on the child chain
       let aliceUtxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(aliceUtxos.length, 2)
-      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(aliceUtxos[0].amount.toString(), UTXO_AMOUNT)
       assert.equal(aliceUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(aliceUtxos[1].amount.toString(), UTXO_AMOUNT)
@@ -154,7 +152,6 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check Bob's utxos on the child chain
       let bobUtxos = await childChain.getUtxos(bobAccount.address)
       assert.equal(bobUtxos.length, 2)
-      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(bobUtxos[0].amount.toString(), UTXO_AMOUNT)
       assert.equal(bobUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(bobUtxos[1].amount.toString(), UTXO_AMOUNT)
@@ -222,7 +219,6 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check Alice's utxos on the child chain again
       aliceUtxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(aliceUtxos.length, 2)
-      assert.hasAllKeys(aliceUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(aliceUtxos[0].amount.toString(), ALICE_OUTPUT_0)
       assert.equal(aliceUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(aliceUtxos[1].amount.toString(), ALICE_OUTPUT_1)
@@ -231,7 +227,6 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check Bob's utxos on the child chain again
       bobUtxos = await childChain.getUtxos(bobAccount.address)
       assert.equal(bobUtxos.length, 2)
-      assert.hasAllKeys(bobUtxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(bobUtxos[0].amount.toString(), BOB_OUTPUT_0)
       assert.equal(bobUtxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(bobUtxos[1].amount.toString(), BOB_OUTPUT_1)
@@ -273,7 +268,6 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check utxos on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 2)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
 
       const erc20Utxo = utxos.find(utxo => utxo.currency === ERC20_CURRENCY)
       const ethUtxo = utxos.find(utxo => utxo.currency === transaction.ETH_CURRENCY)
@@ -356,7 +350,6 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check utxos on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 2)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount, INTIIAL_ALICE_AMOUNT_ETH)
       assert.equal(utxos[0].currency, transaction.ETH_CURRENCY)
       assert.equal(utxos[1].amount, INTIIAL_ALICE_AMOUNT_ERC20)
@@ -446,7 +439,6 @@ describe('transferTest.js (ci-enabled)', function () {
       // Check utxos on the child chain
       const utxos = await childChain.getUtxos(aliceAccount.address)
       assert.equal(utxos.length, 1)
-      assert.hasAllKeys(utxos[0], ['utxo_pos', 'txindex', 'owner', 'oindex', 'currency', 'blknum', 'amount', 'creating_txhash', 'spending_txhash', 'otype'])
       assert.equal(utxos[0].amount.toString(), INTIIAL_ALICE_AMOUNT)
       assert.equal(utxos[0].currency, transaction.ETH_CURRENCY)
 

--- a/packages/omg-js-childchain/src/validators/index.js
+++ b/packages/omg-js-childchain/src/validators/index.js
@@ -23,24 +23,17 @@ const getTransactionsSchema = Joi.object({
   blknum: validateAmount,
   limit: Joi.number().integer(),
   page: Joi.number().integer()
-})
+}).unknown()
 
 const getTransactionSchema = Joi.object({
   id: Joi.string().required()
 })
 
 const getExitDataSchema = Joi.object({
-  amount: validateAmount,
   blknum: validateAmount,
-  currency: Joi.string(),
-  oindex: Joi.number().integer(),
-  owner: Joi.string(),
   txindex: Joi.number().integer(),
-  utxo_pos: validateAmount,
-  spending_txhash: [Joi.string(), Joi.allow(null)],
-  creating_txhash: [Joi.string(), Joi.allow(null)],
-  otype: Joi.number().integer()
-})
+  oindex: Joi.number().integer()
+}).unknown()
 
 const getChallengeDataSchema = Joi.object({
   utxoPos: validateAmount.required()

--- a/packages/omg-js-util/src/docTypes.js
+++ b/packages/omg-js-util/src/docTypes.js
@@ -42,9 +42,12 @@
  * @typedef {Object} UTXO
  * @property {number} amount
  * @property {number} blknum
+ * @property {string} creating_txhash
  * @property {string} currency
  * @property {number} oindex
+ * @property {number} otype
  * @property {string} owner
+ * @property {string} spending_txhash
  * @property {number} txindex
  * @property {number} utxo_pos
  */

--- a/packages/omg-js-util/src/validators/helpers.js
+++ b/packages/omg-js-util/src/validators/helpers.js
@@ -51,6 +51,12 @@ const validateFee = Joi.object({
 
 const validateUtxos = Joi.array().items(Joi.object())
 
+const validateAmount = Joi.alternatives().try(
+  Joi.number().integer().required(),
+  validateBn.required(),
+  Joi.string().regex(/^\d+$/).required()
+)
+
 module.exports = {
   validateAddress,
   validateTxOption,
@@ -59,5 +65,6 @@ module.exports = {
   validatePayments,
   validateMetadata,
   validateFee,
-  validateUtxos
+  validateUtxos,
+  validateAmount
 }

--- a/packages/omg-js-util/src/validators/index.js
+++ b/packages/omg-js-util/src/validators/index.js
@@ -5,7 +5,8 @@ const {
   validateFee,
   validateMetadata,
   validateUtxos,
-  validateBn
+  validateBn,
+  validateAmount
 } = require('./helpers')
 
 const encodeDepositSchema = Joi.object({
@@ -35,7 +36,11 @@ const decodeUtxoPosSchema = Joi.object({
 })
 
 const encodeUtxoPosSchema = Joi.object({
-  utxo: Joi.object().required()
+  utxo: Joi.object({
+    blknum: validateAmount,
+    txindex: Joi.number().integer(),
+    oindex: Joi.number().integer()
+  }).unknown()
 })
 
 const decodeMetadataSchema = Joi.object({

--- a/packages/omg-js-util/test/decodeTransactionTest.js
+++ b/packages/omg-js-util/test/decodeTransactionTest.js
@@ -138,7 +138,7 @@ describe('Decode transaction tests', function () {
     const signedEncoded = rlp.encode(toEndcode)
 
     const decoded = transaction.decodeTxBytes(signedEncoded)
-    assert.hasAllKeys(decoded, [
+    assert.containsAllKeys(decoded, [
       'sigs',
       'inputs',
       'outputs',
@@ -195,7 +195,7 @@ describe('Decode transaction tests', function () {
     const signedEncoded = rlp.encode(toEndcode)
 
     const decoded = transaction.decodeTxBytes(signedEncoded)
-    assert.hasAllKeys(decoded, [
+    assert.containsAllKeys(decoded, [
       'sigs',
       'inputs',
       'outputs',


### PR DESCRIPTION
When new keys were added to the utxo object from elixir-omg, some validation would fail. i relaxed the input validation so unneeded keys can correctly just pass through.

Should work against 0.4.2 & 0.4.3 of elixir-omg tags
When merged, will release a patch accordingly ie. 3.0.1-0.4.2

<img width="535" alt="Screen Shot 2020-02-26 at 12 20 14" src="https://user-images.githubusercontent.com/29919550/75314669-0412d000-5893-11ea-9c51-4eb2fc3b5a8c.png">
