### PR TITLE
Refactor txutils

### DIFF
--- a/packages/omg-js-rootchain/src/txUtils.js
+++ b/packages/omg-js-rootchain/src/txUtils.js
@@ -49,17 +49,7 @@ async function sendTx ({ web3, txDetails, privateKey, callbacks }) {
         .on('error', reject)
     })
   }
-  return web3.eth.sendSignedTransaction(signedTx.rawTransaction).catch(err => {
-    let transactionHash
-    try {
-      transactionHash = JSON.parse(err.message.replace('Transaction has been reverted by the EVM:', '')).transactionHash
-    } catch (parseError) {
-      throw (err)
-    }
-    ethErrorReason({ web3, hash: transactionHash }).then(() => {
-      throw (err)
-    })
-  })
+  return web3.eth.sendSignedTransaction(signedTx.rawTransaction)
 }
 
 async function setGas (web3, txDetails) {

--- a/packages/omg-js-rootchain/src/txUtils.js
+++ b/packages/omg-js-rootchain/src/txUtils.js
@@ -50,7 +50,8 @@ async function sendTx ({ web3, txDetails, privateKey, callbacks }) {
 }
 
 async function setGas (web3, txDetails) {
-  if (!txDetails.gasPrice) {
+  let enhancedTxDetails = { ...txDetails }
+  if (!enhancedTxDetails.gasPrice) {
     try {
       if (web3.version.api && web3.version.api.startsWith('0.2')) {
         const gasPrice = await new Promise((resolve, reject) => {
@@ -62,22 +63,22 @@ async function setGas (web3, txDetails) {
             }
           })
         })
-        return { ...txDetails, gasPrice }
+        enhancedTxDetails = { ...enhancedTxDetails, gasPrice }
       } else {
         const gasPrice = await web3.eth.getGasPrice()
-        return { ...txDetails, gasPrice }
+        enhancedTxDetails = { ...enhancedTxDetails, gasPrice }
       }
     } catch (err) {
       // Default to 1 GWEI
-      return { ...txDetails, gasPrice: '1000000000' }
+      enhancedTxDetails = { ...enhancedTxDetails, gasPrice: '1000000000' }
     }
   }
 
-  if (!txDetails.gas) {
+  if (!enhancedTxDetails.gas) {
     try {
       if (web3.version.api && web3.version.api.startsWith('0.2')) {
         const gas = await new Promise((resolve, reject) => {
-          web3.eth.estimateGas(txDetails, (err, result) => {
+          web3.eth.estimateGas(enhancedTxDetails, (err, result) => {
             if (err) {
               reject(err)
             } else {
@@ -85,16 +86,18 @@ async function setGas (web3, txDetails) {
             }
           })
         })
-        return { ...txDetails, gas }
+        enhancedTxDetails = { ...enhancedTxDetails, gas }
       } else {
-        const gas = await web3.eth.estimateGas(txDetails)
-        return { ...txDetails, gas }
+        const gas = await web3.eth.estimateGas(enhancedTxDetails)
+        enhancedTxDetails = { ...enhancedTxDetails, gas }
       }
     } catch (err) {
       console.warn(`Error estimating gas: ${err}`)
       throw err
     }
   }
+
+  return enhancedTxDetails
 }
 
 function getTxData (web3, contract, method, ...args) {

--- a/packages/omg-js-rootchain/src/txUtils.js
+++ b/packages/omg-js-rootchain/src/txUtils.js
@@ -1,5 +1,3 @@
-const { ethErrorReason } = require('@omisego/omg-js-util')
-
 /**
  * Send transaction using web3
  *
@@ -37,9 +35,8 @@ async function sendTx ({ web3, txDetails, privateKey, callbacks }) {
     return web3.eth.sendTransaction(enhancedTxDetails)
   }
 
-  // First sign the transaction
+  // Sign and send transaction
   const signedTx = await web3.eth.accounts.signTransaction(enhancedTxDetails, prefixHex(privateKey))
-  // Then send it
   if (callbacks) {
     return new Promise((resolve, reject) => {
       web3.eth.sendSignedTransaction(signedTx.rawTransaction)
@@ -75,6 +72,7 @@ async function setGas (web3, txDetails) {
       return { ...txDetails, gasPrice: '1000000000' }
     }
   }
+
   if (!txDetails.gas) {
     try {
       if (web3.version.api && web3.version.api.startsWith('0.2')) {


### PR DESCRIPTION
We were returning a promise in the error handler of `sendTx`. Throwing on the next tick will confusingly result in unhandled exceptions. Parsing for the error reason should anyway be kept independent of `sendTx`. 

Also cleaned up the mutation of params in `setGas`