### PR TITLE
Switch dep from git to npm

### DIFF
--- a/examples/childchain-utxos.js
+++ b/examples/childchain-utxos.js
@@ -16,7 +16,7 @@
 
 const ChildChain = require('../packages/omg-js-childchain/src/childchain')
 const config = require('./config.js')
-const JSONBigNumber = require('json-bigint')
+const JSONBigNumber = require('omg-json-bigint')
 
 const childChain = new ChildChain({ watcherUrl: config.watcher_url, watcherProxyUrl: config.watcher_proxy_url })
 

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -1361,13 +1361,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
-    "json-bigint": {
-      "version": "git+https://git@github.com/omisego/json-bigint.git#9595b17821033bd82df3fe872f51094269f38c0a",
-      "from": "git+https://git@github.com/omisego/json-bigint.git",
-      "requires": {
-        "bn.js": "^5.0.0"
-      }
-    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -1630,6 +1623,14 @@
       "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
       "requires": {
         "http-https": "^1.0.0"
+      }
+    },
+    "omg-json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/omg-json-bigint/-/omg-json-bigint-1.0.0.tgz",
+      "integrity": "sha512-/AXmK8M0dNiThKn2B/0blswNwb18lBluqM+/O5TAlhUFfMEBBJHJ0N0Uj950Ptl0LdFSXJiMzP1w94BJ9GaRqA==",
+      "requires": {
+        "bn.js": "^5.0.0"
       }
     },
     "on-finished": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "bn.js": "^5.0.0",
     "human-standard-token-abi": "^2.0.0",
-    "json-bigint": "git+https://git@github.com/omisego/json-bigint.git",
     "number-to-bn": "^1.7.0",
+    "omg-json-bigint": "^1.0.0",
     "promise-retry": "^1.1.1",
     "web3": "1.2.2"
   }

--- a/packages/omg-js-childchain/package-lock.json
+++ b/packages/omg-js-childchain/package-lock.json
@@ -364,13 +364,6 @@
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
-		"json-bigint": {
-			"version": "git+https://git@github.com/omisego/json-bigint.git#9595b17821033bd82df3fe872f51094269f38c0a",
-			"from": "git+https://git@github.com/omisego/json-bigint.git",
-			"requires": {
-				"bn.js": "^5.0.0"
-			}
-		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -468,6 +461,14 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"omg-json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/omg-json-bigint/-/omg-json-bigint-1.0.0.tgz",
+			"integrity": "sha512-/AXmK8M0dNiThKn2B/0blswNwb18lBluqM+/O5TAlhUFfMEBBJHJ0N0Uj950Ptl0LdFSXJiMzP1w94BJ9GaRqA==",
+			"requires": {
+				"bn.js": "^5.0.0"
+			}
 		},
 		"once": {
 			"version": "1.4.0",

--- a/packages/omg-js-childchain/package.json
+++ b/packages/omg-js-childchain/package.json
@@ -28,7 +28,7 @@
     "@omisego/omg-js-util": "3.0.2-0.4.5",
     "bn.js": "^5.0.0",
     "debug": "^4.0.1",
-    "json-bigint": "git+https://git@github.com/omisego/json-bigint.git",
+    "omg-json-bigint": "^1.0.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "rlp": "^2.1.0",

--- a/packages/omg-js-childchain/src/rpc/rpcApi.js
+++ b/packages/omg-js-childchain/src/rpc/rpcApi.js
@@ -15,7 +15,7 @@ limitations under the License. */
 
 const request = require('request-promise-native')
 const debug = require('debug')('omg.childchain.rpc')
-const JSONBigNumber = require('json-bigint')
+const JSONBigNumber = require('omg-json-bigint')
 
 class RpcError extends Error {
   constructor ({ code, description, messages }) {


### PR DESCRIPTION
using our git hosted fork of `json-bigint` worked fine locally, but was throwing errors in different envs due to different configs (docker, vms, etc). This way should be easier to manage. 

https://github.com/omisego/omg-js/issues/260

npm package -> https://www.npmjs.com/package/omg-json-bigint