### PR TITLE
Bump elixir-omg ci sha 0.4.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 parameters:
   elixir-omg-sha:
     type: string
-    default: "a8b3bd4"
+    default: "593018b"
 
 workflows:
   version: 2


### PR DESCRIPTION
- Runs ci tests on elixir-omg 0.4.6 release