### PR TITLE
fix: API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install @omisego/react-native-omg-js
 
 ## API Documentation
 
-[Documentation for omg-js ](https://developer.omisego.co/omg-js/)
+[Documentation for omg-js ](https://docs.omg.network/omg-js/)
 
 ## Design Documentation
 


### PR DESCRIPTION
# Overview
Recent domain changes require an update of all APIs references. The current omg-js docs have moved from `developer.omisego.co` to `docs.omg.network` domain.

# Changes
- Updated [omg-js API reference](https://docs.omg.network/omg-js) with the latest domain.