### PR TITLE
Remove fs polyfill

### DIFF
--- a/packages/react-native-omg-js/hack.sh
+++ b/packages/react-native-omg-js/hack.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Polyfill node apis introduce by web3
-rn-nodeify --install assert,stream,events,crypto,url,http,https,vm,os,fs,path,process,net,zlib,_stream_transform,tls --hack
+rn-nodeify --install assert,stream,events,crypto,url,http,https,vm,os,path,process,net,zlib,_stream_transform,tls --hack


### PR DESCRIPTION
Closes #295 

Remove `fs` from the polyfill script for the react-native.